### PR TITLE
Fix silent failures across search, playback and startup

### DIFF
--- a/bin/spotifz
+++ b/bin/spotifz
@@ -3,8 +3,25 @@
 import argparse
 import json
 import os
+import sys
 
 import spotifz
+from spotifz.helpers import FzfNotFound
+from spotifz.spotify.client import SpotifyAuthFailed
+
+
+def load_config(config_path):
+    path = os.path.expanduser(config_path)
+    try:
+        with open(path) as ifile:
+            return json.load(ifile)
+    except FileNotFoundError:
+        raise spotifz.ConfigError(
+            'No config file at {}\n'
+            'Copy config.json from the project root and fill it in.'.format(path)
+        )
+    except json.JSONDecodeError as e:
+        raise spotifz.ConfigError('Config at {} is not valid JSON: {}'.format(path, e))
 
 
 def main():
@@ -19,15 +36,23 @@ def main():
         '-U',
         '--update-cache',
         action='store_true',
-        help='Update spotify cache',
+        help='Update spotify cache and exit, without entering the menu',
     )
     args = parser.parse_args()
 
-    with open(os.path.expanduser(args.config_path)) as ifile:
-        config = json.load(ifile)
-
-    spotifz.launch(config)
+    try:
+        config = load_config(args.config_path)
+        if args.update_cache:
+            spotifz.update_cache(config)
+        else:
+            spotifz.launch(config)
+    except (spotifz.ConfigError, FzfNotFound, SpotifyAuthFailed) as e:
+        print(e, file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        return 130
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/config.json
+++ b/config.json
@@ -5,11 +5,5 @@
         "redirect_uri": "http://127.0.0.1:8080/"
     },
     "cache_path": "",
-    "user": "",
-    "interface": {
-        "prog": "fzf",
-        "options": [
-            "--multi"
-        ]
-    }
+    "user": ""
 }

--- a/spotifz/__init__.py
+++ b/spotifz/__init__.py
@@ -1,15 +1,61 @@
-from .helpers import update_data_paths
+from . import spotify
+from .helpers import ensure_fzf, update_data_paths
 from .interface import screens
+
+REQUIRED_CONFIG_KEYS = (
+    ('spotify_client', 'client_id'),
+    ('spotify_client', 'client_secret'),
+    ('spotify_client', 'redirect_uri'),
+    ('cache_path',),
+    ('user',),
+)
+
+
+class ConfigError(Exception):
+    pass
+
+
+def validate_config(config):
+    """
+    Without this, a missing key surfaces as a bare KeyError from deep inside
+    the auth call.
+    """
+    missing = []
+    for key_path in REQUIRED_CONFIG_KEYS:
+        node = config
+        for key in key_path:
+            if not isinstance(node, dict) or key not in node:
+                node = None
+                break
+            node = node[key]
+        if node is None or node == '':
+            missing.append('.'.join(key_path))
+
+    if missing:
+        raise ConfigError(
+            'Config is missing a value for: {}\n'
+            'See config.json in the project root for the expected shape.'.format(
+                ', '.join(missing)
+            )
+        )
+
+
+def prepare(config):
+    validate_config(config)
+    # ensure that the paths are populated in the config
+    update_data_paths(config)
+
+
+def update_cache(config):
+    prepare(config)
+    spotify.update_cache(config)
 
 
 def launch(config):
-    # ensure that the paths are populated in the config
-    update_data_paths(config)
+    prepare(config)
+    ensure_fzf()
 
     choice, *screen_args = screens.home_screen(config)
     while choice is not None:
         upcoming_screen = getattr(screens, choice)
-        if isinstance(screen_args, list):
-            choice, *screen_args = upcoming_screen(config, *screen_args)
-        else:
-            choice, *screen_args = upcoming_screen(config)
+        choice, *screen_args = upcoming_screen(config, *screen_args)

--- a/spotifz/helpers/__init__.py
+++ b/spotifz/helpers/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+from .fzf import FzfNotFound, ensure_fzf  # noqa: F401
+
 
 def get_expanded_path(path_str, append=None):
     expanded_path = os.path.expanduser(path_str)

--- a/spotifz/helpers/fzf.py
+++ b/spotifz/helpers/fzf.py
@@ -1,23 +1,34 @@
 import os
+import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+
+
+class FzfNotFound(Exception):
+    pass
+
+
+def ensure_fzf():
+    if shutil.which('fzf') is None:
+        raise FzfNotFound(
+            'fzf was not found on your PATH. '
+            'See https://github.com/junegunn/fzf for install instructions.'
+        )
 
 
 def run_fzf(search_items, prompt=None):
     if prompt is None:
         prompt = '> '
 
-    cmd_template = 'echo "{items}" | fzf --prompt="{prompt}" '
-    cmd = cmd_template.format(items=('\n'.join(search_items)), prompt=prompt)
+    # fzf reads candidates from stdin, so there is no need for a shell and no
+    # opportunity for the items to be reinterpreted as shell syntax.
     fuzzy_result = subprocess.run(
-        [bytes(cmd, 'utf-8')],
-        # this is required as fzf needs a shell process and this child process
-        # needs to inherit the input and output streams
-        shell=True,
-        # to capture the output in the parent process
+        ['fzf', '--prompt', prompt],
+        input='\n'.join(search_items),
+        text=True,
         stdout=subprocess.PIPE,
     )
-    selected = fuzzy_result.stdout.decode().strip().split('\n')
+    selected = fuzzy_result.stdout.strip().split('\n')
     return selected
 
 
@@ -30,15 +41,11 @@ def run_fzf_sink(iterator_func, config, prompt=None):
     if prompt is None:
         prompt = '> '
 
-    executor = ThreadPoolExecutor(max_workers=1)
-    iterator_future = executor.submit(iterator_func, config, fifo_path)
-
-    cache_path = os.path.expanduser(config['cache_path'])
-    track_dir = os.path.join(cache_path, 'spotify_data/tracks/')
+    track_dir = config['data_paths']['track_path']
 
     # The `$6` refers to the 6th element separated by `::` which is `track_id`
-    # Refer to function `sink_all_tracks()` in `../spotify/sink/py`
-    awk_cmd = 'awk -F " :: " -v tp={}'.format(track_dir) + " '{ print tp$6 }'"
+    # Refer to function `sink_all_tracks()` in `../spotify/sink.py`
+    awk_cmd = 'awk -F " :: " -v tp={}/'.format(track_dir) + " '{ print tp$6 }'"
     preview_template = """
     echo {} |
     {} |
@@ -47,17 +54,23 @@ def run_fzf_sink(iterator_func, config, prompt=None):
     """
     preview = preview_template.format('{}', awk_cmd)
 
-    with open(fifo_path, 'r') as sink:
-        fuzzy_result = subprocess.run(
-            ['fzf', '--prompt', prompt, '--preview', preview],
-            stdin=sink,
-            stdout=subprocess.PIPE,
-        )
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        iterator_future = executor.submit(iterator_func, config, fifo_path)
 
-    if iterator_future.exception() is not None:
-        print('Something went wrong while sinking tracks!')
-        raise iterator_future.exception()
-    executor.shutdown()
-    os.remove(fifo_path)
+        with open(fifo_path, 'r') as sink:
+            fuzzy_result = subprocess.run(
+                ['fzf', '--prompt', prompt, '--preview', preview],
+                stdin=sink,
+                stdout=subprocess.PIPE,
+            )
+
+        if iterator_future.exception() is not None:
+            print('Something went wrong while sinking tracks!')
+            raise iterator_future.exception()
+    finally:
+        executor.shutdown()
+        if os.path.exists(fifo_path):
+            os.remove(fifo_path)
 
     return fuzzy_result.stdout.decode().strip().split('\n')

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -1,5 +1,26 @@
+from collections import Counter
+
 from .. import spotify
 from ..helpers import fzf
+
+
+def _redirect_to_devices(config, screen, *screen_args):
+    """
+    Send the user to device selection, recording where to return afterwards.
+    """
+    config['last_screen'] = screen
+    config['last_screen_args'] = screen_args
+    return ('list_devices',)
+
+
+def _resolve_device(config, playback):
+    """
+    Returns the device id to start playback on, or None when the caller should
+    redirect to device selection first.
+    """
+    if playback is not None:
+        return playback['device']['id']
+    return config.get('active_device_id')
 
 
 def home_screen(_):
@@ -16,28 +37,94 @@ def home_screen(_):
     return (choices[chosen],)
 
 
+def describe_playback(playback):
+    """
+    Builds the display lines for whatever is currently playing. Returns an
+    empty list when there is nothing worth showing.
+    """
+    if playback is None:
+        return []
+
+    item = playback.get('item')
+    playing_type = playback.get('currently_playing_type')
+    device = playback.get('device', {}).get('name')
+
+    if item is None:
+        # Adverts carry no item at all. An episode arriving as None means the
+        # `additional_types` request parameter did not make it through.
+        if playing_type == 'ad':
+            lines = ['Playing : advert']
+            if device is not None:
+                lines.append('Device : ' + device)
+            return lines
+        return []
+
+    if item.get('type') == 'episode' or item.get('show') is not None:
+        # Episodes carry show/publisher rather than album/artists.
+        lines = ['Episode : ' + item['name']]
+        show = item.get('show') or {}
+        if show.get('name'):
+            lines.append('Show : ' + show['name'])
+        if show.get('publisher'):
+            lines.append('Publisher : ' + show['publisher'])
+        if item.get('release_date'):
+            lines.append('Released : ' + item['release_date'])
+    else:
+        lines = ['Track : ' + item['name']]
+        if item.get('album') is not None:
+            lines.append('Album : ' + item['album']['name'])
+        if item.get('artists'):
+            lines.append(
+                'Artist : '
+                + ' ; '.join(artist['name'] for artist in item['artists'])
+            )
+
+    if device is not None:
+        lines.append('Device : ' + device)
+    return lines
+
+
 def current_playback(config):
     sp = spotify.get_spotify_client(config)
-    playback = sp.current_playback()
-    if playback is None:
+    # Without `additional_types`, Spotify represents an unsupported item type
+    # as a null `item`, so a playing podcast would arrive indistinguishable
+    # from an advert and never render.
+    playback = sp.current_playback(additional_types='episode')
+    lines = describe_playback(playback)
+    if not lines:
         return ('home_screen',)
-    track_name = 'Track : ' + playback['item']['name']
-    album = 'Album : ' + playback['item']['album']['name']
-    artists = 'Artist : ' + ' ; '.join(
-        [artist['name'] for artist in playback['item']['artists']]
-    )
-    device = 'Device : ' + playback['device']['name']
-    fzf.run_fzf([track_name, album, artists, device], prompt='Playback > ')[0]
+
+    fzf.run_fzf(lines, prompt='Playback > ')[0]
     return ('home_screen',)
 
 
 def list_devices(config):
-    sp = spotify.get_spotify_client(config)
-    choices = {d['name']: d['id'] for d in sp.devices()['devices']}
-    chosen = fzf.run_fzf(list(choices.keys()), prompt='[Devices] > ')[0]
+    devices = sp_devices(config)
+    chosen = fzf.run_fzf(list(devices.keys()), prompt='[Devices] > ')[0]
     if chosen == '':
         return ('home_screen',)
-    return 'device_actions', choices[chosen]
+    return 'device_actions', devices[chosen]
+
+
+def sp_devices(config):
+    """
+    Maps a display label to a device id. Device names are not unique (two
+    phones, two browsers), so only the colliding ones get disambiguated.
+    """
+    sp = spotify.get_spotify_client(config)
+    devices = sp.devices()['devices']
+    name_counts = Counter(d['name'] for d in devices)
+
+    labelled = {}
+    for device in devices:
+        label = device['name']
+        if name_counts[label] > 1:
+            label = '{} ({})'.format(label, device['type'])
+            # Still ambiguous if the types match too; fall back to the id.
+            if label in labelled:
+                label = '{} [{}]'.format(label, device['id'][:8])
+        labelled[label] = device['id']
+    return labelled
 
 
 def device_actions(config, device_id):
@@ -47,8 +134,9 @@ def device_actions(config, device_id):
     sp = spotify.get_spotify_client(config)
     sp.transfer_playback(device_id)
     config['active_device_id'] = device_id
-    if config.get('last_screen') is not None:
-        return config.get('last_screen'), *config.get('last_screen_args')
+    last_screen = config.pop('last_screen', None)
+    if last_screen is not None:
+        return last_screen, *config.pop('last_screen_args', ())
     return ('home_screen',)
 
 
@@ -56,9 +144,10 @@ def resume(config):
     sp = spotify.get_spotify_client(config)
     playback = sp.current_playback()
     if playback is None:
-        if config.get('active_device_id') is None:
-            return ('list_devices',)
-        sp.start_playback(device_id=config['active_device_id'])
+        device_id = _resolve_device(config, playback)
+        if device_id is None:
+            return _redirect_to_devices(config, 'resume')
+        sp.start_playback(device_id=device_id)
     elif playback['is_playing']:
         sp.pause_playback()
     else:
@@ -77,7 +166,6 @@ def search(config):
     )[0]
     result = list(map(str.strip, chosen.split('::')))
     if len(result) > 1:
-        print(result)
         return 'track_actions', result
     else:
         return ('home_screen',)
@@ -104,12 +192,13 @@ def track_actions(_, track_props):
 def play_track_in_playlist(config, track_props):
     track_id, playlist_id = track_props[-1], track_props[-2]
     sp = spotify.get_spotify_client(config)
-    playback = sp.current_playback()
-    if playback is None:
-        if config.get('active_device_id') is None:
-            return ('list_devices',)
-        sp.start_playback(device_id=config['active_device_id'])
+    device_id = _resolve_device(config, sp.current_playback())
+    if device_id is None:
+        return _redirect_to_devices(
+            config, 'play_track_in_playlist', track_props
+        )
     sp.start_playback(
+        device_id=device_id,
         context_uri=f'spotify:playlist:{playlist_id}',
         offset={'uri': f'spotify:track:{track_id}'},
     )
@@ -119,5 +208,10 @@ def play_track_in_playlist(config, track_props):
 def play_track(config, track_props):
     track_id = track_props[-1]
     sp = spotify.get_spotify_client(config)
-    sp.start_playback(uris=[f'spotify:track:{track_id}'])
+    device_id = _resolve_device(config, sp.current_playback())
+    if device_id is None:
+        return _redirect_to_devices(config, 'play_track', track_props)
+    sp.start_playback(
+        device_id=device_id, uris=[f'spotify:track:{track_id}']
+    )
     return ('search',)

--- a/spotifz/spotify/client.py
+++ b/spotifz/spotify/client.py
@@ -1,12 +1,20 @@
 from spotipy import Spotify
-from spotipy.oauth2 import SpotifyOauthError
 
 from .auth import get_access_token
 
 
+class SpotifyAuthFailed(Exception):
+    pass
+
+
 def get_spotify_client(config) -> Spotify:
-    try:
-        return Spotify(auth=get_access_token(config))
-    except SpotifyOauthError as e:
-        print(e)
-        raise
+    access_token = get_access_token(config)
+    if access_token is None:
+        # get_access_token already printed the underlying error. Without this
+        # check a Spotify(auth=None) client is built happily and the failure
+        # resurfaces as an opaque 401 at the first API call.
+        raise SpotifyAuthFailed(
+            'Could not authenticate with Spotify. '
+            'Check the error above, then re-run to authorize.'
+        )
+    return Spotify(auth=access_token)

--- a/spotifz/spotify/sink.py
+++ b/spotifz/spotify/sink.py
@@ -1,4 +1,5 @@
 import json
+import os
 from glob import glob
 
 
@@ -7,22 +8,25 @@ def sink_all_tracks(config, fifo_path):
         '{name} :: {album[name]} :: {artist_list} :: {pl} :: {pl_id} :: {id}\n'
     )
 
-    with open(fifo_path, 'w') as sink:
-        for p_file in glob(
-            config['data_paths']['playlist_path'] + '/*[!.json]'
-        ):
-            with open(p_file) as ifi:
-                playlist = json.load(ifi)
-            [
-                sink.write(
-                    song_template.format(
-                        artist_list=', '.join(
-                            [artist['name'] for artist in track['artists']]
-                        ),
-                        pl=playlist['name'],
-                        pl_id=playlist['id'],
-                        **track
+    try:
+        with open(fifo_path, 'w') as sink:
+            for p_file in glob(
+                os.path.join(config['data_paths']['playlist_path'], '*')
+            ):
+                with open(p_file) as ifi:
+                    playlist = json.load(ifi)
+                for track in playlist['tracks']:
+                    sink.write(
+                        song_template.format(
+                            artist_list=', '.join(
+                                [artist['name'] for artist in track['artists']]
+                            ),
+                            pl=playlist['name'],
+                            pl_id=playlist['id'],
+                            **track,
+                        )
                     )
-                )
-                for track in playlist['tracks']
-            ]
+    except BrokenPipeError:
+        # fzf was closed before every track had been written, e.g. the user
+        # picked a track or hit Esc. Nothing left to sink.
+        pass

--- a/spotifz/spotify/storage.py
+++ b/spotifz/spotify/storage.py
@@ -85,6 +85,29 @@ def cache_data(spotify_client, config):
             json.dump(playlist, ofile)
 
 
+KEEP_BACKUPS = 3
+
+
+def prune_backups(backup_dir, keep=KEEP_BACKUPS):
+    """
+    Backups are a full archive of the library on every cache update, so without
+    pruning they accumulate indefinitely.
+    """
+    if not os.path.exists(backup_dir):
+        return []
+
+    # The timestamp in the name sorts lexicographically, so name order is age
+    # order and does not depend on filesystem mtimes surviving a copy.
+    archives = sorted(
+        f for f in os.listdir(backup_dir) if f.startswith('spotify_data_')
+    )
+    removed = []
+    for stale in archives[:-keep] if keep else archives:
+        os.remove(os.path.join(backup_dir, stale))
+        removed.append(stale)
+    return removed
+
+
 def backup_data(config):
     data_path = config['data_paths']['base_path']
     if not os.path.exists(data_path):
@@ -94,13 +117,18 @@ def backup_data(config):
         data_path
     )
 
-    ct = datetime.datetime.today().isoformat()
+    # Avoid `:` in the filename; isoformat() is not portable across filesystems.
+    ct = datetime.datetime.today().strftime('%Y%m%dT%H%M%S')
     archive_name = 'spotify_data_{}'.format(ct)
-    archive_path = os.path.join(root_dir, 'backup', archive_name)
+    backup_dir = os.path.join(root_dir, 'backup')
+    archive_path = os.path.join(backup_dir, archive_name)
 
     archive_path = shutil.make_archive(
         archive_path, format='gztar', root_dir=root_dir, base_dir=base_dir
     )
+    pruned = prune_backups(backup_dir)
+    if pruned:
+        print('Removed {} stale backup(s).'.format(len(pruned)))
     return archive_path
 
 


### PR DESCRIPTION
A pass over the codebase turned up defects that were invisible in normal use because they failed silently or only on inputs not yet hit.

## Correctness

- **`sink.py`** — the playlist glob `*[!.json]` reads as "not the literal `.json`" but is a *single-character* class excluding `.`, `j`, `s`, `o`, `n`. Playlist files are named by 22-char base62 Spotify ID, so ~8% of playlists were dropped from search with no error. Nothing writes `.json` there, so the exclusion was never needed.
- **`screens.py`** — `current_playback()` was called without `additional_types`; Spotify represents an unsupported item type as a null `item`, so a playing podcast was indistinguishable from an advert and never rendered. Now requests episode info and shows show/publisher for episodes, album/artist for tracks.
- **`bin/spotifz`** — `-U/--update-cache` was parsed and never read; it silently dropped into the interactive menu.
- **`fzf.py`** — `run_fzf` interpolated items into `echo "..." | fzf` under `shell=True`. Device names are user-set, so one containing a quote, `$` or backtick corrupted the command. fzf reads candidates from stdin; neither shell nor echo is needed.
- **`fzf.py`** — the FIFO leaked when the sink thread raised, and closing fzf early surfaced a `BrokenPipeError` traceback for a normal cancellation.
- **`screens.py`** — `play_track_in_playlist` called `start_playback` twice, starting the previous context before replacing it; `play_track` did not handle the no-active-device case at all. Both now resolve the device first and make one call.
- **`screens.py`** — `last_screen`/`last_screen_args` were read but never written, so returning to the previous screen after picking a device never worked.
- **`screens.py`** — keying devices on name meant duplicates (two phones) silently collapsed.
- **`screens.py`** — removed a debug `print` that scribbled between fzf screens.

## Robustness

- `get_access_token` returns `None` on failure and the client was built as `Spotify(auth=None)`, deferring the failure to an opaque 401. Now raises `SpotifyAuthFailed`; the unreachable `except` is gone.
- Config is validated up front, reporting every missing key at once; missing/malformed config files give a message rather than a traceback, and exit non-zero.
- `fzf` presence is checked at startup.
- The preview pane reads the track directory from `data_paths` instead of a hardcoded duplicate of the cache layout.
- Backups keep only the three most recent, with a `:`-free portable timestamp.
- Dropped the `interface` block from `config.json`, which nothing reads.
