### PR TITLE
Separate runtime state from config, and the candidate line's ids from its display

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,12 @@ Selected Track:
 6. You should be able to call `spotifz` from your shell.
 7. Select `Update Cache` the first time you run `spotifz`.
 
+`spotifz` writes two files of its own into `cache_path`, both named after the
+`user` in your config: `<user>_spotify.cache.json` holds the OAuth token, and
+`<user>_state.json` remembers the playback device you last chose, so you do not
+have to pick one every session. Both sit outside `spotify_data/`, which
+`Update Cache` deletes and rebuilds.
+
 ## Dev Setup
 
 This project uses [uv](https://docs.astral.sh/uv/). It creates a `.venv` in the

--- a/spotifz/__init__.py
+++ b/spotifz/__init__.py
@@ -1,6 +1,7 @@
 from . import spotify
-from .helpers import ensure_fzf, update_data_paths
+from .helpers import ensure_fzf
 from .interface import screens
+from .state import AppState
 
 REQUIRED_CONFIG_KEYS = (
     ('spotify_client', 'client_id'),
@@ -42,20 +43,21 @@ def validate_config(config):
 
 def prepare(config):
     validate_config(config)
-    # ensure that the paths are populated in the config
-    update_data_paths(config)
+    # The state normalises the config onto a copy of its own, so the dict the
+    # caller loaded from JSON is never written to.
+    return AppState.from_config(config)
 
 
 def update_cache(config):
-    prepare(config)
-    spotify.update_cache(config)
+    state = prepare(config)
+    spotify.update_cache(state.config)
 
 
 def launch(config):
-    prepare(config)
+    state = prepare(config)
     ensure_fzf()
 
-    choice, *screen_args = screens.home_screen(config)
+    choice, *screen_args = screens.home_screen(state)
     while choice is not None:
         upcoming_screen = getattr(screens, choice)
-        choice, *screen_args = upcoming_screen(config, *screen_args)
+        choice, *screen_args = upcoming_screen(state, *screen_args)

--- a/spotifz/helpers/fzf.py
+++ b/spotifz/helpers/fzf.py
@@ -5,6 +5,10 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
 
+# Imported from the module rather than the package: the format's owner is
+# sink.py, and spotifz.spotify may still be initialising when this is loaded.
+from ..spotify.sink import DISPLAY_FIELD, SEPARATOR, TRACK_ID_FIELD
+
 
 class FzfNotFound(Exception):
     pass
@@ -20,20 +24,17 @@ def ensure_fzf():
 
 def preview_command(track_dir):
     """
-    The shell command fzf runs for the highlighted line, with `{}` replaced by
-    that line, single-quoted.
+    The shell command fzf runs for the highlighted line.
 
-    The track id is the sixth ' :: '-separated field -- see sink_all_tracks in
-    ../spotify/sink.py. A name containing ' :: ' shifts the fields and the
-    preview then reads the wrong one; that is a defect of the wire format
-    rather than of this command.
+    fzf substitutes `{N}` with the Nth SEPARATOR-separated field of the
+    *original* line, single-quoted -- so there is no text parsing here at all,
+    and the separator never reaches a shell. Verified against fzf 0.74.1:
+    --with-nth hides the id fields from the display and from matching, but not
+    from these placeholders.
     """
-    extract_id = "echo {} | awk -F ' :: ' '{print $6}'"
-    # The directory is quoted on its own and concatenated with a double-quoted
-    # command substitution, so a cache_path containing a space survives. The
-    # previous version interpolated it bare and piped it through xargs, which
-    # split it on whitespace.
-    track_file = shlex.quote(track_dir) + '"' + os.sep + '$(' + extract_id + ')"'
+    # The quoted directory and fzf's single-quoted field concatenate in sh,
+    # bash and zsh, so a cache_path containing a space survives.
+    track_file = shlex.quote(track_dir + os.sep) + '{' + str(TRACK_ID_FIELD) + '}'
     # sys.executable rather than a bare `python`: current macOS and most Linux
     # distributions ship only `python3`, and a preview that silently fails is
     # invisible -- fzf shows an empty pane and reports nothing.
@@ -75,7 +76,19 @@ def run_fzf_sink(iterator_func, config, prompt=None):
 
         with open(fifo_path, 'r') as sink:
             fuzzy_result = subprocess.run(
-                ['fzf', '--prompt', prompt, '--preview', preview],
+                [
+                    'fzf',
+                    '--prompt',
+                    prompt,
+                    # Show and match only the display field; the ids ride along
+                    # on the line for the preview and for the accepted result.
+                    '--delimiter',
+                    SEPARATOR,
+                    '--with-nth',
+                    str(DISPLAY_FIELD),
+                    '--preview',
+                    preview,
+                ],
                 stdin=sink,
                 stdout=subprocess.PIPE,
             )
@@ -88,4 +101,6 @@ def run_fzf_sink(iterator_func, config, prompt=None):
         if os.path.exists(fifo_path):
             os.remove(fifo_path)
 
-    return fuzzy_result.stdout.decode().strip().split('\n')
+    # strip('\n'), not strip(): 0x1f is whitespace to Python, so a bare strip
+    # would eat a separator next to an empty field.
+    return fuzzy_result.stdout.decode().strip('\n').split('\n')

--- a/spotifz/helpers/fzf.py
+++ b/spotifz/helpers/fzf.py
@@ -1,6 +1,8 @@
 import os
+import shlex
 import shutil
 import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -14,6 +16,30 @@ def ensure_fzf():
             'fzf was not found on your PATH. '
             'See https://github.com/junegunn/fzf for install instructions.'
         )
+
+
+def preview_command(track_dir):
+    """
+    The shell command fzf runs for the highlighted line, with `{}` replaced by
+    that line, single-quoted.
+
+    The track id is the sixth ' :: '-separated field -- see sink_all_tracks in
+    ../spotify/sink.py. A name containing ' :: ' shifts the fields and the
+    preview then reads the wrong one; that is a defect of the wire format
+    rather than of this command.
+    """
+    extract_id = "echo {} | awk -F ' :: ' '{print $6}'"
+    # The directory is quoted on its own and concatenated with a double-quoted
+    # command substitution, so a cache_path containing a space survives. The
+    # previous version interpolated it bare and piped it through xargs, which
+    # split it on whitespace.
+    track_file = shlex.quote(track_dir) + '"' + os.sep + '$(' + extract_id + ')"'
+    # sys.executable rather than a bare `python`: current macOS and most Linux
+    # distributions ship only `python3`, and a preview that silently fails is
+    # invisible -- fzf shows an empty pane and reports nothing.
+    return '{} -m json.tool {} | (highlight -O ansi --syntax json || cat)'.format(
+        shlex.quote(sys.executable), track_file
+    )
 
 
 def run_fzf(search_items, prompt=None):
@@ -41,18 +67,7 @@ def run_fzf_sink(iterator_func, config, prompt=None):
     if prompt is None:
         prompt = '> '
 
-    track_dir = config['data_paths']['track_path']
-
-    # The `$6` refers to the 6th element separated by `::` which is `track_id`
-    # Refer to function `sink_all_tracks()` in `../spotify/sink.py`
-    awk_cmd = 'awk -F " :: " -v tp={}/'.format(track_dir) + " '{ print tp$6 }'"
-    preview_template = """
-    echo {} |
-    {} |
-    xargs python -m json.tool |
-    (highlight -O ansi --syntax json || cat )
-    """
-    preview = preview_template.format('{}', awk_cmd)
+    preview = preview_command(config['data_paths']['track_path'])
 
     executor = ThreadPoolExecutor(max_workers=1)
     try:

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -4,23 +4,22 @@ from .. import spotify
 from ..helpers import fzf
 
 
-def _redirect_to_devices(config, screen, *screen_args):
+def _redirect_to_devices(state, screen, *screen_args):
     """
     Send the user to device selection, recording where to return afterwards.
     """
-    config['last_screen'] = screen
-    config['last_screen_args'] = screen_args
+    state.pending_screen = (screen, screen_args)
     return ('list_devices',)
 
 
-def _resolve_device(config, playback):
+def _resolve_device(state, playback):
     """
     Returns the device id to start playback on, or None when the caller should
     redirect to device selection first.
     """
     if playback is not None:
         return playback['device']['id']
-    return config.get('active_device_id')
+    return state.active_device_id
 
 
 def home_screen(_):
@@ -83,8 +82,8 @@ def describe_playback(playback):
     return lines
 
 
-def current_playback(config):
-    sp = spotify.get_spotify_client(config)
+def current_playback(state):
+    sp = spotify.get_spotify_client(state.config)
     # Without `additional_types`, Spotify represents an unsupported item type
     # as a null `item`, so a playing podcast would arrive indistinguishable
     # from an advert and never render.
@@ -97,20 +96,20 @@ def current_playback(config):
     return ('home_screen',)
 
 
-def list_devices(config):
-    devices = sp_devices(config)
+def list_devices(state):
+    devices = sp_devices(state)
     chosen = fzf.run_fzf(list(devices.keys()), prompt='[Devices] > ')[0]
     if chosen == '':
         return ('home_screen',)
     return 'device_actions', devices[chosen]
 
 
-def sp_devices(config):
+def sp_devices(state):
     """
     Maps a display label to a device id. Device names are not unique (two
     phones, two browsers), so only the colliding ones get disambiguated.
     """
-    sp = spotify.get_spotify_client(config)
+    sp = spotify.get_spotify_client(state.config)
     devices = sp.devices()['devices']
     name_counts = Counter(d['name'] for d in devices)
 
@@ -126,26 +125,27 @@ def sp_devices(config):
     return labelled
 
 
-def device_actions(config, device_id):
+def device_actions(state, device_id):
     """
     For now, there is just one action
     """
-    sp = spotify.get_spotify_client(config)
+    sp = spotify.get_spotify_client(state.config)
     sp.transfer_playback(device_id)
-    config['active_device_id'] = device_id
-    last_screen = config.pop('last_screen', None)
-    if last_screen is not None:
-        return last_screen, *config.pop('last_screen_args', ())
+    state.set_active_device(device_id)
+    pending = state.take_pending_screen()
+    if pending is not None:
+        screen, screen_args = pending
+        return (screen, *screen_args)
     return ('home_screen',)
 
 
-def resume(config):
-    sp = spotify.get_spotify_client(config)
+def resume(state):
+    sp = spotify.get_spotify_client(state.config)
     playback = sp.current_playback()
     if playback is None:
-        device_id = _resolve_device(config, playback)
+        device_id = _resolve_device(state, playback)
         if device_id is None:
-            return _redirect_to_devices(config, 'resume')
+            return _redirect_to_devices(state, 'resume')
         sp.start_playback(device_id=device_id)
     elif playback['is_playing']:
         sp.pause_playback()
@@ -154,13 +154,15 @@ def resume(config):
     return ('home_screen',)
 
 
-def update_cache(config):
-    spotify.update_cache(config)
+def update_cache(state):
+    spotify.update_cache(state.config)
     return ('home_screen',)
 
 
-def search(config):
-    chosen = fzf.run_fzf_sink(spotify.sink_all_tracks, config, prompt='[Search] > ')[0]
+def search(state):
+    chosen = fzf.run_fzf_sink(
+        spotify.sink_all_tracks, state.config, prompt='[Search] > '
+    )[0]
     result = list(map(str.strip, chosen.split('::')))
     if len(result) > 1:
         return 'track_actions', result
@@ -186,12 +188,12 @@ def track_actions(_, track_props):
     return choices[chosen], track_props
 
 
-def play_track_in_playlist(config, track_props):
+def play_track_in_playlist(state, track_props):
     track_id, playlist_id = track_props[-1], track_props[-2]
-    sp = spotify.get_spotify_client(config)
-    device_id = _resolve_device(config, sp.current_playback())
+    sp = spotify.get_spotify_client(state.config)
+    device_id = _resolve_device(state, sp.current_playback())
     if device_id is None:
-        return _redirect_to_devices(config, 'play_track_in_playlist', track_props)
+        return _redirect_to_devices(state, 'play_track_in_playlist', track_props)
     sp.start_playback(
         device_id=device_id,
         context_uri=f'spotify:playlist:{playlist_id}',
@@ -200,11 +202,11 @@ def play_track_in_playlist(config, track_props):
     return ('search',)
 
 
-def play_track(config, track_props):
+def play_track(state, track_props):
     track_id = track_props[-1]
-    sp = spotify.get_spotify_client(config)
-    device_id = _resolve_device(config, sp.current_playback())
+    sp = spotify.get_spotify_client(state.config)
+    device_id = _resolve_device(state, sp.current_playback())
     if device_id is None:
-        return _redirect_to_devices(config, 'play_track', track_props)
+        return _redirect_to_devices(state, 'play_track', track_props)
     sp.start_playback(device_id=device_id, uris=[f'spotify:track:{track_id}'])
     return ('search',)

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -181,20 +181,19 @@ def search(state):
     chosen = fzf.run_fzf_sink(
         spotify.sink_all_tracks, state.config, prompt='[Search] > '
     )[0]
-    result = list(map(str.strip, chosen.split('::')))
-    if len(result) > 1:
-        return 'track_actions', result
-    else:
+    # An empty selection -- the user hit Esc -- carries no separator.
+    if spotify.SEPARATOR not in chosen:
         return ('home_screen',)
+    return 'track_actions', spotify.parse_track_line(chosen)
 
 
-def track_actions(_, track_props):
+def track_actions(_, track):
     choices = {
         'Play Track in Playlist': 'play_track_in_playlist',
         'Play Track': 'play_track',
     }
 
-    track_name = track_props[0].replace("'", '')
+    track_name = track.name.replace("'", '')
     if len(track_name) > 20:
         prompt = f'[{track_name[:20]}...] > '
     else:
@@ -203,32 +202,30 @@ def track_actions(_, track_props):
     chosen = fzf.run_fzf(list(choices.keys()), prompt=prompt)[0]
     if chosen == '':
         return ('search',)
-    return choices[chosen], track_props
+    return choices[chosen], track
 
 
-def play_track_in_playlist(state, track_props):
-    track_id, playlist_id = track_props[-1], track_props[-2]
+def play_track_in_playlist(state, track):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
     started = device_id is not None and _start_playback(
         state,
         sp,
         device_id=device_id,
-        context_uri=f'spotify:playlist:{playlist_id}',
-        offset={'uri': f'spotify:track:{track_id}'},
+        context_uri=f'spotify:playlist:{track.playlist_id}',
+        offset={'uri': f'spotify:track:{track.track_id}'},
     )
     if not started:
-        return _redirect_to_devices(state, 'play_track_in_playlist', track_props)
+        return _redirect_to_devices(state, 'play_track_in_playlist', track)
     return ('search',)
 
 
-def play_track(state, track_props):
-    track_id = track_props[-1]
+def play_track(state, track):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
     started = device_id is not None and _start_playback(
-        state, sp, device_id=device_id, uris=[f'spotify:track:{track_id}']
+        state, sp, device_id=device_id, uris=[f'spotify:track:{track.track_id}']
     )
     if not started:
-        return _redirect_to_devices(state, 'play_track', track_props)
+        return _redirect_to_devices(state, 'play_track', track)
     return ('search',)

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -1,5 +1,7 @@
 from collections import Counter
 
+from spotipy import SpotifyException
+
 from .. import spotify
 from ..helpers import fzf
 
@@ -20,6 +22,20 @@ def _resolve_device(state, playback):
     if playback is not None:
         return playback['device']['id']
     return state.active_device_id
+
+
+def _start_playback(state, sp, **kwargs):
+    """
+    A device that was alive last session may be gone this one, and Spotify
+    answers with a 404. Forget it, so the caller can send the user to pick
+    another -- the same path as never having chosen one.
+    """
+    try:
+        sp.start_playback(**kwargs)
+    except SpotifyException:
+        state.forget_active_device()
+        return False
+    return True
 
 
 def home_screen(_):
@@ -144,9 +160,11 @@ def resume(state):
     playback = sp.current_playback()
     if playback is None:
         device_id = _resolve_device(state, playback)
-        if device_id is None:
+        started = device_id is not None and _start_playback(
+            state, sp, device_id=device_id
+        )
+        if not started:
             return _redirect_to_devices(state, 'resume')
-        sp.start_playback(device_id=device_id)
     elif playback['is_playing']:
         sp.pause_playback()
     else:
@@ -192,13 +210,15 @@ def play_track_in_playlist(state, track_props):
     track_id, playlist_id = track_props[-1], track_props[-2]
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
-    if device_id is None:
-        return _redirect_to_devices(state, 'play_track_in_playlist', track_props)
-    sp.start_playback(
+    started = device_id is not None and _start_playback(
+        state,
+        sp,
         device_id=device_id,
         context_uri=f'spotify:playlist:{playlist_id}',
         offset={'uri': f'spotify:track:{track_id}'},
     )
+    if not started:
+        return _redirect_to_devices(state, 'play_track_in_playlist', track_props)
     return ('search',)
 
 
@@ -206,7 +226,9 @@ def play_track(state, track_props):
     track_id = track_props[-1]
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
-    if device_id is None:
+    started = device_id is not None and _start_playback(
+        state, sp, device_id=device_id, uris=[f'spotify:track:{track_id}']
+    )
+    if not started:
         return _redirect_to_devices(state, 'play_track', track_props)
-    sp.start_playback(device_id=device_id, uris=[f'spotify:track:{track_id}'])
     return ('search',)

--- a/spotifz/spotify/__init__.py
+++ b/spotifz/spotify/__init__.py
@@ -1,3 +1,12 @@
 from .client import get_spotify_client  # noqa: F401
-from .sink import sink_all_tracks  # noqa: F401
+from .sink import (  # noqa: F401
+    DISPLAY_FIELD,
+    PLAYLIST_ID_FIELD,
+    SEPARATOR,
+    TRACK_ID_FIELD,
+    TrackRef,
+    format_track_line,
+    parse_track_line,
+    sink_all_tracks,
+)
 from .storage import update_cache  # noqa: F401

--- a/spotifz/spotify/sink.py
+++ b/spotifz/spotify/sink.py
@@ -1,29 +1,72 @@
 import json
 import os
 from glob import glob
+from typing import NamedTuple
+
+# The candidate line fzf reads is `<display>\x1f<track_id>\x1f<playlist_id>`.
+#
+# 0x1f (ASCII Unit Separator) is the only field separator, and it cannot occur
+# in a track, album or playlist name. ' :: ' is decoration inside the display
+# field, free to appear in a name: it used to be the separator, which meant a
+# name containing it shifted every field after it and the preview pane read the
+# wrong one.
+SEPARATOR = '\x1f'
+DISPLAY_SEPARATOR = ' :: '
+
+# 1-based, to match fzf's {N} placeholders and --with-nth.
+DISPLAY_FIELD = 1
+TRACK_ID_FIELD = 2
+PLAYLIST_ID_FIELD = 3
+
+
+class TrackRef(NamedTuple):
+    display: str
+    track_id: str
+    playlist_id: str
+
+    @property
+    def name(self):
+        # Cosmetic, for the fzf prompt only. A name containing
+        # DISPLAY_SEPARATOR truncates the prompt and nothing else.
+        return self.display.split(DISPLAY_SEPARATOR)[0]
+
+
+def _clean(value):
+    """
+    One record per line, SEPARATOR between fields: nothing that could
+    impersonate either may survive into a field.
+    """
+    for char in ('\n', '\r', SEPARATOR):
+        value = value.replace(char, ' ')
+    return value
+
+
+def format_track_line(track, playlist):
+    display = DISPLAY_SEPARATOR.join(
+        _clean(part)
+        for part in (
+            track['name'],
+            track['album']['name'],
+            ', '.join(artist['name'] for artist in track['artists']),
+            playlist['name'],
+        )
+    )
+    return SEPARATOR.join((display, track['id'], playlist['id'])) + '\n'
+
+
+def parse_track_line(line):
+    display, track_id, playlist_id = line.split(SEPARATOR)
+    return TrackRef(display, track_id, playlist_id)
 
 
 def sink_all_tracks(config, fifo_path):
-    song_template = (
-        '{name} :: {album[name]} :: {artist_list} :: {pl} :: {pl_id} :: {id}\n'
-    )
-
     try:
         with open(fifo_path, 'w') as sink:
             for p_file in glob(os.path.join(config['data_paths']['playlist_path'], '*')):
                 with open(p_file) as ifi:
                     playlist = json.load(ifi)
                 for track in playlist['tracks']:
-                    sink.write(
-                        song_template.format(
-                            artist_list=', '.join(
-                                [artist['name'] for artist in track['artists']]
-                            ),
-                            pl=playlist['name'],
-                            pl_id=playlist['id'],
-                            **track,
-                        )
-                    )
+                    sink.write(format_track_line(track, playlist))
     except BrokenPipeError:
         # fzf was closed before every track had been written, e.g. the user
         # picked a track or hit Esc. Nothing left to sink.

--- a/spotifz/state.py
+++ b/spotifz/state.py
@@ -1,0 +1,86 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .helpers import update_data_paths
+
+# Persistence is an explicit whitelist, never asdict(self): a field holding a
+# live handle (a database connection, an API client) must be addable without
+# becoming a serialisation problem.
+PERSISTED_FIELDS = ('active_device_id',)
+
+
+@dataclass
+class AppState:
+    """
+    One run of the app. `config` is the user's settings, normalised once at the
+    boundary and thereafter read-only; everything the app *discovers* while
+    running gets a field of its own.
+    """
+
+    config: Dict[str, Any]
+    active_device_id: Optional[str] = None
+    # Where to return after the user has picked a device. Session-only; it
+    # would be actively wrong to resume last week's screen on startup.
+    pending_screen: Optional[Tuple[str, tuple]] = None
+
+    @classmethod
+    def from_config(cls, config):
+        # update_data_paths writes only top-level keys, so a shallow copy is
+        # enough to leave the caller's dict untouched.
+        normalised = dict(config)
+        update_data_paths(normalised)
+        state = cls(config=normalised)
+        state.load()
+        return state
+
+    @property
+    def cache_path(self):
+        return self.config['cache_path']
+
+    @property
+    def data_paths(self):
+        return self.config['data_paths']
+
+    @property
+    def state_path(self):
+        # Named after the user, like the token cache in auth.get_token_path,
+        # and outside spotify_data/ so `spotifz -U` does not wipe it.
+        return os.path.join(self.cache_path, '{}_state.json'.format(self.config['user']))
+
+    def load(self):
+        try:
+            with open(self.state_path) as ifile:
+                saved = json.load(ifile)
+        except (FileNotFoundError, ValueError):
+            # No state yet, or a truncated file from a killed run. Session
+            # state is never worth failing a launch over. json.JSONDecodeError
+            # subclasses ValueError, so one except covers both.
+            return
+        if not isinstance(saved, dict):
+            return
+        for name in PERSISTED_FIELDS:
+            if saved.get(name) is not None:
+                setattr(self, name, saved[name])
+
+    def save(self):
+        payload = {name: getattr(self, name) for name in PERSISTED_FIELDS}
+        os.makedirs(self.cache_path, exist_ok=True)
+        tmp_path = self.state_path + '.tmp'
+        with open(tmp_path, 'w') as ofile:
+            json.dump(payload, ofile)
+        # A half-written state file must not be able to break the next launch.
+        os.replace(tmp_path, self.state_path)
+
+    def set_active_device(self, device_id):
+        self.active_device_id = device_id
+        self.save()
+
+    def forget_active_device(self):
+        self.active_device_id = None
+        self.save()
+
+    def take_pending_screen(self):
+        pending, self.pending_screen = self.pending_screen, None
+        return pending

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from spotifz.helpers import update_data_paths
+from spotifz.state import AppState
 
 
 @pytest.fixture
@@ -23,6 +24,16 @@ def config(tmp_path):
     update_data_paths(cfg)
     os.makedirs(cfg['cache_path'], exist_ok=True)
     return cfg
+
+
+@pytest.fixture
+def state(config):
+    """
+    The runtime state built from that config. from_config is idempotent on an
+    already-normalised config: expanding an absolute path and recomputing
+    data_paths are both no-ops, so both fixtures can be used together.
+    """
+    return AppState.from_config(config)
 
 
 @pytest.fixture

--- a/tests/test_fzf.py
+++ b/tests/test_fzf.py
@@ -13,6 +13,7 @@ from spotifz.helpers.fzf import (
     run_fzf,
     run_fzf_sink,
 )
+from spotifz.spotify.sink import DISPLAY_FIELD, SEPARATOR, TRACK_ID_FIELD
 
 
 @pytest.fixture
@@ -58,11 +59,13 @@ def writer(config, fifo_path):
 
 def as_fzf_would(preview, line):
     """
-    Emulates fzf's placeholder substitution: `{}` becomes the highlighted line,
-    single-quoted. Verified by hand against fzf 0.74.1 -- the suite must never
-    reach the real binary, which blocks forever without a TTY.
+    Emulates fzf's placeholder substitution: `{N}` becomes the Nth
+    SEPARATOR-separated field of the original line, single-quoted. Verified by
+    hand against fzf 0.74.1 -- the suite must never reach the real binary,
+    which blocks forever without a TTY.
     """
-    return preview.replace('{}', shlex.quote(line))
+    field = line.split(SEPARATOR)[TRACK_ID_FIELD - 1]
+    return preview.replace('{%d}' % TRACK_ID_FIELD, shlex.quote(field))
 
 
 def render_preview(track_dir, line, track_id='track-1', name='Song One'):
@@ -84,7 +87,7 @@ def render_preview(track_dir, line, track_id='track-1', name='Song One'):
 
 
 def test_the_preview_command_renders_the_track_json(config):
-    line = 'Song One :: Album :: A, B :: Road Trip :: pl-1 :: track-1'
+    line = 'Song One :: Album :: A, B :: Road Trip\x1ftrack-1\x1fpl-1'
 
     result = render_preview(config['data_paths']['track_path'], line)
 
@@ -96,26 +99,24 @@ def test_the_preview_command_survives_a_space_in_the_path(config, tmp_path):
     The old command interpolated the directory unquoted and piped it through
     xargs, which split it on whitespace.
     """
-    line = 'Song One :: Album :: A, B :: Road Trip :: pl-1 :: track-1'
+    line = 'Song One :: Album :: A, B :: Road Trip\x1ftrack-1\x1fpl-1'
 
     result = render_preview(str(tmp_path / 'cache dir' / 'tracks'), line)
 
     assert 'Song One' in result.stdout
 
 
-def test_the_preview_command_reads_the_wrong_field_for_a_name_with_the_separator(
-    config,
-):
+def test_the_preview_command_renders_a_track_whose_name_holds_the_separator(config):
     """
-    Documents the bug rather than asserting it is fixed: ' :: ' inside a name
-    adds a field, so the hard-coded sixth one is the playlist id and the
-    preview pane silently shows nothing. Invert this when the format changes.
+    The bug item 7 fixes, asserted from the preview's side: this used to add a
+    field, so the hard-coded sixth one was the playlist id and the pane
+    silently showed nothing.
     """
-    line = 'Intro :: Reprise :: Album :: A, B :: Road Trip :: pl-1 :: track-1'
+    line = 'Intro :: Reprise :: Album :: A, B :: Road Trip\x1ftrack-1\x1fpl-1'
 
     result = render_preview(config['data_paths']['track_path'], line)
 
-    assert 'Song One' not in result.stdout
+    assert 'Song One' in result.stdout
 
 
 def test_ensure_fzf_passes_when_fzf_is_on_the_path(monkeypatch):
@@ -148,12 +149,20 @@ def test_run_fzf_sink_returns_the_selection(config, fake_fzf):
     assert fake_fzf[0]['stdin'] == 'one\ntwo\n'
 
 
-def test_run_fzf_sink_previews_the_track_by_its_sixth_field(config, fake_fzf):
+def test_run_fzf_sink_asks_fzf_to_extract_the_id_field(config, fake_fzf):
+    """
+    The preview no longer parses the line itself: fzf is told the structure and
+    substitutes the field.
+    """
     run_fzf_sink(writer, config)
 
-    preview = fake_fzf[0]['cmd'][fake_fzf[0]['cmd'].index('--preview') + 1]
+    cmd = fake_fzf[0]['cmd']
+    assert cmd[cmd.index('--delimiter') + 1] == SEPARATOR
+    assert cmd[cmd.index('--with-nth') + 1] == str(DISPLAY_FIELD)
+
+    preview = cmd[cmd.index('--preview') + 1]
     assert config['data_paths']['track_path'] in preview
-    assert '$6' in preview
+    assert '{%d}' % TRACK_ID_FIELD in preview
 
 
 def test_run_fzf_sink_removes_the_fifo_on_the_normal_path(config, fake_fzf):

--- a/tests/test_fzf.py
+++ b/tests/test_fzf.py
@@ -1,10 +1,18 @@
+import json
 import os
+import shlex
 import subprocess
 
 import pytest
 
 from spotifz.helpers import fzf
-from spotifz.helpers.fzf import FzfNotFound, ensure_fzf, run_fzf, run_fzf_sink
+from spotifz.helpers.fzf import (
+    FzfNotFound,
+    ensure_fzf,
+    preview_command,
+    run_fzf,
+    run_fzf_sink,
+)
 
 
 @pytest.fixture
@@ -46,6 +54,68 @@ def undrained_fzf(monkeypatch):
 def writer(config, fifo_path):
     with open(fifo_path, 'w') as sink:
         sink.write('one\ntwo\n')
+
+
+def as_fzf_would(preview, line):
+    """
+    Emulates fzf's placeholder substitution: `{}` becomes the highlighted line,
+    single-quoted. Verified by hand against fzf 0.74.1 -- the suite must never
+    reach the real binary, which blocks forever without a TTY.
+    """
+    return preview.replace('{}', shlex.quote(line))
+
+
+def render_preview(track_dir, line, track_id='track-1', name='Song One'):
+    """
+    Actually runs the preview command. Nothing else in the suite does, so a
+    preview broken by a bad interpreter name, a quoting slip or a changed field
+    index would otherwise ship green.
+    """
+    os.makedirs(track_dir, exist_ok=True)
+    with open(os.path.join(track_dir, track_id), 'w') as ofile:
+        json.dump({'id': track_id, 'name': name}, ofile)
+
+    return subprocess.run(
+        as_fzf_would(preview_command(track_dir), line),
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_preview_command_renders_the_track_json(config):
+    line = 'Song One :: Album :: A, B :: Road Trip :: pl-1 :: track-1'
+
+    result = render_preview(config['data_paths']['track_path'], line)
+
+    assert 'Song One' in result.stdout
+
+
+def test_the_preview_command_survives_a_space_in_the_path(config, tmp_path):
+    """
+    The old command interpolated the directory unquoted and piped it through
+    xargs, which split it on whitespace.
+    """
+    line = 'Song One :: Album :: A, B :: Road Trip :: pl-1 :: track-1'
+
+    result = render_preview(str(tmp_path / 'cache dir' / 'tracks'), line)
+
+    assert 'Song One' in result.stdout
+
+
+def test_the_preview_command_reads_the_wrong_field_for_a_name_with_the_separator(
+    config,
+):
+    """
+    Documents the bug rather than asserting it is fixed: ' :: ' inside a name
+    adds a field, so the hard-coded sixth one is the playlist id and the
+    preview pane silently shows nothing. Invert this when the format changes.
+    """
+    line = 'Intro :: Reprise :: Album :: A, B :: Road Trip :: pl-1 :: track-1'
+
+    result = render_preview(config['data_paths']['track_path'], line)
+
+    assert 'Song One' not in result.stdout
 
 
 def test_ensure_fzf_passes_when_fzf_is_on_the_path(monkeypatch):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -5,6 +5,7 @@ import pytest
 
 import spotifz
 from spotifz.helpers import update_data_paths
+from spotifz.state import AppState
 
 
 def valid_config():
@@ -148,12 +149,14 @@ def test_launch_stops_when_the_home_screen_returns_none(
     monkeypatch.setattr(
         spotifz,
         'screens',
-        types.SimpleNamespace(home_screen=lambda cfg: calls.append(cfg) or (None,)),
+        types.SimpleNamespace(home_screen=lambda s: calls.append(s) or (None,)),
     )
 
     spotifz.launch(config)
 
-    assert calls == [config]
+    assert len(calls) == 1
+    assert isinstance(calls[0], AppState)
+    assert calls[0].config == config
 
 
 def test_launch_forwards_several_screen_args(config, monkeypatch, no_fzf_check):
@@ -190,15 +193,24 @@ def test_launch_validates_before_checking_for_fzf(monkeypatch):
     assert checked == []
 
 
-def test_launch_populates_the_data_paths(config, monkeypatch, no_fzf_check):
+def test_launch_leaves_the_callers_config_alone(monkeypatch, no_fzf_check):
+    """
+    The derived paths still get populated -- on the state, not by reaching back
+    into the dict the caller loaded from JSON.
+    """
     cfg = valid_config()
+    seen = []
     monkeypatch.setattr(
-        spotifz, 'screens', types.SimpleNamespace(home_screen=lambda c: (None,))
+        spotifz,
+        'screens',
+        types.SimpleNamespace(home_screen=lambda s: seen.append(s) or (None,)),
     )
 
     spotifz.launch(cfg)
 
-    assert 'data_paths' in cfg
+    assert cfg == valid_config()
+    base = os.path.join('/tmp/spotifz-cache', 'spotify_data')
+    assert seen[0].data_paths['base_path'] == base
 
 
 def test_update_cache_prepares_the_config_first(monkeypatch):

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,13 +1,15 @@
 import pytest
+from spotipy import SpotifyException
 
 from spotifz.interface import screens
 from spotifz.state import AppState
 
 
 class FakeClient:
-    def __init__(self, playback=None, devices=()):
+    def __init__(self, playback=None, devices=(), start_error=None):
         self._playback = playback
         self._devices = list(devices)
+        self._start_error = start_error
         self.calls = []
 
     def current_playback(self, **kwargs):
@@ -23,6 +25,8 @@ class FakeClient:
 
     def start_playback(self, **kwargs):
         self.calls.append(('start_playback', kwargs))
+        if self._start_error is not None:
+            raise self._start_error
 
     def pause_playback(self):
         self.calls.append(('pause_playback', {}))
@@ -38,8 +42,8 @@ def client(monkeypatch):
     screens.spotify.get_spotify_client, so that is the only seam needed.
     """
 
-    def _install(playback=None, devices=()):
-        fake = FakeClient(playback, devices)
+    def _install(playback=None, devices=(), start_error=None):
+        fake = FakeClient(playback, devices, start_error)
         monkeypatch.setattr(screens.spotify, 'get_spotify_client', lambda cfg: fake)
         return fake
 
@@ -475,6 +479,37 @@ def test_the_device_redirect_round_trips_resume(state, client):
 
     client()
     assert screens.device_actions(state, 'd1') == ('resume',)
+
+
+def device_gone():
+    return SpotifyException(404, -1, 'Device not found')
+
+
+def test_a_persisted_device_that_no_longer_exists_is_forgotten(state, client):
+    """
+    Once the device id comes off disk it can be a phone that has been off for a
+    week. The user should get the device picker they would have got with no
+    device chosen at all, not a traceback out of cli.main.
+    """
+    props = ['Song', 'pl-1', 'track-1']
+    client(playback=None, start_error=device_gone())
+    state.set_active_device('d1')
+
+    assert screens.play_track(state, props) == ('list_devices',)
+    assert state.active_device_id is None
+    # Forgotten on disk too, or the next session retries the dead device.
+    assert AppState.from_config(state.config).active_device_id is None
+    # And the redirect still knows what the user was trying to do.
+    assert state.pending_screen == ('play_track', (props,))
+
+
+def test_resume_forgets_a_persisted_device_that_no_longer_exists(state, client):
+    client(playback=None, start_error=device_gone())
+    state.set_active_device('d1')
+
+    assert screens.resume(state) == ('list_devices',)
+    assert state.active_device_id is None
+    assert state.pending_screen == ('resume', ())
 
 
 # --- update_cache ------------------------------------------------------------

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -2,6 +2,7 @@ import pytest
 from spotipy import SpotifyException
 
 from spotifz.interface import screens
+from spotifz.spotify.sink import SEPARATOR, TrackRef
 from spotifz.state import AppState
 
 
@@ -355,13 +356,15 @@ def fzf_sink(monkeypatch):
     return _install
 
 
-def test_search_splits_the_selected_line(state, fzf_sink):
-    fzf_sink('Song :: Album :: A, B :: Road Trip :: pl-1 :: track-1')
+def test_search_parses_the_selected_line_into_a_track_ref(state, fzf_sink):
+    fzf_sink(SEPARATOR.join(('Song :: Album :: A, B :: Road Trip', 'track-1', 'pl-1')))
 
-    choice, props = screens.search(state)
+    choice, track = screens.search(state)
 
     assert choice == 'track_actions'
-    assert props == ['Song', 'Album', 'A, B', 'Road Trip', 'pl-1', 'track-1']
+    assert track.track_id == 'track-1'
+    assert track.playlist_id == 'pl-1'
+    assert track.display == 'Song :: Album :: A, B :: Road Trip'
 
 
 def test_search_returns_home_when_nothing_was_selected(state, fzf_sink):
@@ -372,21 +375,23 @@ def test_search_returns_home_when_nothing_was_selected(state, fzf_sink):
 
 def test_track_actions_forwards_the_track_props(state, fzf):
     fzf('Play Track')
-    props = ['Song', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
+    track = TrackRef('Song :: Album :: A :: Road Trip', 'track-1', 'pl-1')
 
-    assert screens.track_actions(state, props) == ('play_track', props)
+    assert screens.track_actions(state, track) == ('play_track', track)
 
 
 def test_track_actions_returns_to_search_on_an_empty_selection(state, fzf):
     fzf('')
 
-    assert screens.track_actions(state, ['Song']) == ('search',)
+    assert screens.track_actions(state, TrackRef('Song', 'track-1', 'pl-1')) == (
+        'search',
+    )
 
 
 def test_track_actions_truncates_a_long_prompt(state, fzf):
     seen = fzf('Play Track')
 
-    screens.track_actions(state, ['A' * 40])
+    screens.track_actions(state, TrackRef('A' * 40, 'track-1', 'pl-1'))
 
     assert seen['prompts'][0] == '[{}...] > '.format('A' * 20)
 
@@ -398,7 +403,9 @@ def test_play_track_starts_the_track_on_the_active_device(state, client):
     fake = client(playback=None)
     state.active_device_id = 'd1'
 
-    assert screens.play_track(state, ['Song', 'pl-1', 'track-1']) == ('search',)
+    track = TrackRef('Song', 'track-1', 'pl-1')
+
+    assert screens.play_track(state, track) == ('search',)
     assert fake.named('start_playback') == [
         ('start_playback', {'device_id': 'd1', 'uris': ['spotify:track:track-1']})
     ]
@@ -407,14 +414,16 @@ def test_play_track_starts_the_track_on_the_active_device(state, client):
 def test_play_track_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
 
-    assert screens.play_track(state, ['Song', 'pl-1', 'track-1']) == ('list_devices',)
+    track = TrackRef('Song', 'track-1', 'pl-1')
+
+    assert screens.play_track(state, track) == ('list_devices',)
     assert fake.named('start_playback') == []
 
 
 def test_play_track_in_playlist_uses_the_playlist_as_context(state, client):
     fake = client(playback=track_playback())
 
-    result = screens.play_track_in_playlist(state, ['Song', 'pl-1', 'track-1'])
+    result = screens.play_track_in_playlist(state, TrackRef('Song', 'track-1', 'pl-1'))
 
     assert result == ('search',)
     assert fake.named('start_playback') == [
@@ -429,15 +438,17 @@ def test_play_track_in_playlist_uses_the_playlist_as_context(state, client):
     ]
 
 
-def test_play_track_in_playlist_reads_the_last_two_fields(state, client):
+def test_play_track_in_playlist_is_unaffected_by_the_separator_in_a_name(state, client):
     """
-    A name containing the ' :: ' separator adds fields at the front, so the id
-    and playlist id are addressed from the end.
+    A name containing ' :: ' used to add fields, which is why the ids were
+    addressed by negative index. They have names now, and the name is just
+    text inside the display field.
     """
     fake = client(playback=track_playback())
 
     screens.play_track_in_playlist(
-        state, ['Intro', 'Reprise', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
+        state,
+        TrackRef('Intro :: Reprise :: Album :: A :: Road Trip', 'track-1', 'pl-1'),
     )
 
     kwargs = fake.named('start_playback')[0][1]
@@ -448,7 +459,7 @@ def test_play_track_in_playlist_reads_the_last_two_fields(state, client):
 def test_play_track_in_playlist_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
 
-    result = screens.play_track_in_playlist(state, ['Song', 'pl-1', 'track-1'])
+    result = screens.play_track_in_playlist(state, TrackRef('Song', 'track-1', 'pl-1'))
 
     assert result == ('list_devices',)
     assert fake.named('start_playback') == []
@@ -459,7 +470,7 @@ def test_the_device_redirect_round_trips_back_to_the_original_screen(state, clie
     The whole point of recording the pending screen: picking a device has to
     resume what the user was actually trying to do.
     """
-    props = ['Song', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
+    props = TrackRef('Song :: Album :: A :: Road Trip', 'track-1', 'pl-1')
     client(playback=None)
 
     assert screens.play_track(state, props) == ('list_devices',)
@@ -491,7 +502,7 @@ def test_a_persisted_device_that_no_longer_exists_is_forgotten(state, client):
     week. The user should get the device picker they would have got with no
     device chosen at all, not a traceback out of cli.main.
     """
-    props = ['Song', 'pl-1', 'track-1']
+    props = TrackRef('Song', 'track-1', 'pl-1')
     client(playback=None, start_error=device_gone())
     state.set_active_device('d1')
 

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,6 +1,7 @@
 import pytest
 
 from spotifz.interface import screens
+from spotifz.state import AppState
 
 
 class FakeClient:
@@ -180,7 +181,7 @@ def test_describe_playback_omits_a_missing_device():
 # --- current_playback --------------------------------------------------------
 
 
-def test_current_playback_asks_for_episodes(config, client, fzf):
+def test_current_playback_asks_for_episodes(state, client, fzf):
     """
     Without additional_types a playing podcast comes back as a null item,
     indistinguishable from an advert, and never renders.
@@ -188,31 +189,31 @@ def test_current_playback_asks_for_episodes(config, client, fzf):
     fake = client(playback=track_playback())
     fzf('Track : Song')
 
-    screens.current_playback(config)
+    screens.current_playback(state)
 
     assert fake.named('current_playback')[0][1] == {'additional_types': 'episode'}
 
 
-def test_current_playback_returns_home_without_prompting(config, client, fzf):
+def test_current_playback_returns_home_without_prompting(state, client, fzf):
     client(playback=None)
     seen = fzf()
 
-    assert screens.current_playback(config) == ('home_screen',)
+    assert screens.current_playback(state) == ('home_screen',)
     assert seen['items'] == []
 
 
-def test_current_playback_shows_the_lines(config, client, fzf):
+def test_current_playback_shows_the_lines(state, client, fzf):
     client(playback=track_playback())
     seen = fzf('Track : Song')
 
-    assert screens.current_playback(config) == ('home_screen',)
+    assert screens.current_playback(state) == ('home_screen',)
     assert seen['items'][0][0] == 'Track : Song'
 
 
 # --- devices -----------------------------------------------------------------
 
 
-def test_sp_devices_leaves_unique_names_alone(config, client):
+def test_sp_devices_leaves_unique_names_alone(state, client):
     client(
         devices=[
             {'id': 'd1', 'name': 'Laptop', 'type': 'Computer'},
@@ -220,10 +221,10 @@ def test_sp_devices_leaves_unique_names_alone(config, client):
         ]
     )
 
-    assert screens.sp_devices(config) == {'Laptop': 'd1', 'Phone': 'd2'}
+    assert screens.sp_devices(state) == {'Laptop': 'd1', 'Phone': 'd2'}
 
 
-def test_sp_devices_disambiguates_duplicate_names_by_type(config, client):
+def test_sp_devices_disambiguates_duplicate_names_by_type(state, client):
     """
     Two devices sharing a name would otherwise collapse into one dict entry and
     the second would be unreachable.
@@ -235,13 +236,13 @@ def test_sp_devices_disambiguates_duplicate_names_by_type(config, client):
         ]
     )
 
-    assert screens.sp_devices(config) == {
+    assert screens.sp_devices(state) == {
         'Chrome (Computer)': 'd1',
         'Chrome (Smartphone)': 'd2',
     }
 
 
-def test_sp_devices_falls_back_to_the_id_when_the_type_also_collides(config, client):
+def test_sp_devices_falls_back_to_the_id_when_the_type_also_collides(state, client):
     client(
         devices=[
             {'id': 'aaaaaaaaaa', 'name': 'Chrome', 'type': 'Computer'},
@@ -249,89 +250,91 @@ def test_sp_devices_falls_back_to_the_id_when_the_type_also_collides(config, cli
         ]
     )
 
-    labelled = screens.sp_devices(config)
+    labelled = screens.sp_devices(state)
 
     assert sorted(labelled.values()) == ['aaaaaaaaaa', 'bbbbbbbbbb']
     assert 'Chrome (Computer) [bbbbbbbb]' in labelled
 
 
-def test_list_devices_returns_home_on_an_empty_selection(config, client, fzf):
+def test_list_devices_returns_home_on_an_empty_selection(state, client, fzf):
     client(devices=[{'id': 'd1', 'name': 'Laptop', 'type': 'Computer'}])
     fzf('')
 
-    assert screens.list_devices(config) == ('home_screen',)
+    assert screens.list_devices(state) == ('home_screen',)
 
 
-def test_list_devices_hands_the_id_to_device_actions(config, client, fzf):
+def test_list_devices_hands_the_id_to_device_actions(state, client, fzf):
     client(devices=[{'id': 'd1', 'name': 'Laptop', 'type': 'Computer'}])
     fzf('Laptop')
 
-    assert screens.list_devices(config) == ('device_actions', 'd1')
+    assert screens.list_devices(state) == ('device_actions', 'd1')
 
 
-def test_device_actions_transfers_playback_and_records_the_device(config, client):
+def test_device_actions_transfers_playback_and_records_the_device(state, client):
     fake = client()
 
-    assert screens.device_actions(config, 'd1') == ('home_screen',)
+    assert screens.device_actions(state, 'd1') == ('home_screen',)
     assert fake.named('transfer_playback') == [('transfer_playback', 'd1')]
-    assert config['active_device_id'] == 'd1'
+    assert state.active_device_id == 'd1'
+    # Persisted, not just remembered: a later session finds the same device.
+    assert AppState.from_config(state.config).active_device_id == 'd1'
 
 
 # --- home_screen -------------------------------------------------------------
 
 
-def test_home_screen_maps_the_label_to_a_screen(config, fzf):
+def test_home_screen_maps_the_label_to_a_screen(state, fzf):
     fzf('[ 1 ] Search Library')
 
-    assert screens.home_screen(config) == ('search',)
+    assert screens.home_screen(state) == ('search',)
 
 
-def test_home_screen_exits_on_an_empty_selection(config, fzf):
+def test_home_screen_exits_on_an_empty_selection(state, fzf):
     fzf('')
 
-    assert screens.home_screen(config) == (None,)
+    assert screens.home_screen(state) == (None,)
 
 
 # --- resume ------------------------------------------------------------------
 
 
-def test_resume_pauses_what_is_playing(config, client):
+def test_resume_pauses_what_is_playing(state, client):
     fake = client(playback=track_playback())
 
-    assert screens.resume(config) == ('home_screen',)
+    assert screens.resume(state) == ('home_screen',)
     assert fake.named('pause_playback')
     assert fake.named('start_playback') == []
 
 
-def test_resume_restarts_a_paused_playback(config, client):
+def test_resume_restarts_a_paused_playback(state, client):
     playback = track_playback()
     playback['is_playing'] = False
     fake = client(playback=playback)
 
-    screens.resume(config)
+    screens.resume(state)
 
     # Playback already has a device, so no device_id is needed.
     assert fake.named('start_playback') == [('start_playback', {})]
 
 
-def test_resume_redirects_to_devices_without_a_playback_or_active_device(config, client):
+def test_resume_redirects_to_devices_without_a_playback_or_active_device(state, client):
     fake = client(playback=None)
 
-    assert screens.resume(config) == ('list_devices',)
+    assert screens.resume(state) == ('list_devices',)
     assert fake.named('start_playback') == []
-    assert config['last_screen'] == 'resume'
+    assert state.pending_screen == ('resume', ())
 
 
-def test_resume_starts_on_the_active_device_with_a_single_call(config, client):
+def test_resume_starts_on_the_active_device_with_a_single_call(state, client):
     """
     The device id has to travel on the same start_playback call. A bare
     start_playback followed by a targeted one either 404s or starts playback
     twice.
     """
     fake = client(playback=None)
-    config['active_device_id'] = 'd1'
+    state.active_device_id = 'd1'
 
-    assert screens.resume(config) == ('home_screen',)
+    assert screens.resume(state) == ('home_screen',)
     assert fake.named('start_playback') == [('start_playback', {'device_id': 'd1'})]
 
 
@@ -348,38 +351,38 @@ def fzf_sink(monkeypatch):
     return _install
 
 
-def test_search_splits_the_selected_line(config, fzf_sink):
+def test_search_splits_the_selected_line(state, fzf_sink):
     fzf_sink('Song :: Album :: A, B :: Road Trip :: pl-1 :: track-1')
 
-    choice, props = screens.search(config)
+    choice, props = screens.search(state)
 
     assert choice == 'track_actions'
     assert props == ['Song', 'Album', 'A, B', 'Road Trip', 'pl-1', 'track-1']
 
 
-def test_search_returns_home_when_nothing_was_selected(config, fzf_sink):
+def test_search_returns_home_when_nothing_was_selected(state, fzf_sink):
     fzf_sink('')
 
-    assert screens.search(config) == ('home_screen',)
+    assert screens.search(state) == ('home_screen',)
 
 
-def test_track_actions_forwards_the_track_props(config, fzf):
+def test_track_actions_forwards_the_track_props(state, fzf):
     fzf('Play Track')
     props = ['Song', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
 
-    assert screens.track_actions(config, props) == ('play_track', props)
+    assert screens.track_actions(state, props) == ('play_track', props)
 
 
-def test_track_actions_returns_to_search_on_an_empty_selection(config, fzf):
+def test_track_actions_returns_to_search_on_an_empty_selection(state, fzf):
     fzf('')
 
-    assert screens.track_actions(config, ['Song']) == ('search',)
+    assert screens.track_actions(state, ['Song']) == ('search',)
 
 
-def test_track_actions_truncates_a_long_prompt(config, fzf):
+def test_track_actions_truncates_a_long_prompt(state, fzf):
     seen = fzf('Play Track')
 
-    screens.track_actions(config, ['A' * 40])
+    screens.track_actions(state, ['A' * 40])
 
     assert seen['prompts'][0] == '[{}...] > '.format('A' * 20)
 
@@ -387,27 +390,27 @@ def test_track_actions_truncates_a_long_prompt(config, fzf):
 # --- playback ----------------------------------------------------------------
 
 
-def test_play_track_starts_the_track_on_the_active_device(config, client):
+def test_play_track_starts_the_track_on_the_active_device(state, client):
     fake = client(playback=None)
-    config['active_device_id'] = 'd1'
+    state.active_device_id = 'd1'
 
-    assert screens.play_track(config, ['Song', 'pl-1', 'track-1']) == ('search',)
+    assert screens.play_track(state, ['Song', 'pl-1', 'track-1']) == ('search',)
     assert fake.named('start_playback') == [
         ('start_playback', {'device_id': 'd1', 'uris': ['spotify:track:track-1']})
     ]
 
 
-def test_play_track_redirects_when_there_is_no_device(config, client):
+def test_play_track_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
 
-    assert screens.play_track(config, ['Song', 'pl-1', 'track-1']) == ('list_devices',)
+    assert screens.play_track(state, ['Song', 'pl-1', 'track-1']) == ('list_devices',)
     assert fake.named('start_playback') == []
 
 
-def test_play_track_in_playlist_uses_the_playlist_as_context(config, client):
+def test_play_track_in_playlist_uses_the_playlist_as_context(state, client):
     fake = client(playback=track_playback())
 
-    result = screens.play_track_in_playlist(config, ['Song', 'pl-1', 'track-1'])
+    result = screens.play_track_in_playlist(state, ['Song', 'pl-1', 'track-1'])
 
     assert result == ('search',)
     assert fake.named('start_playback') == [
@@ -422,7 +425,7 @@ def test_play_track_in_playlist_uses_the_playlist_as_context(config, client):
     ]
 
 
-def test_play_track_in_playlist_reads_the_last_two_fields(config, client):
+def test_play_track_in_playlist_reads_the_last_two_fields(state, client):
     """
     A name containing the ' :: ' separator adds fields at the front, so the id
     and playlist id are addressed from the end.
@@ -430,7 +433,7 @@ def test_play_track_in_playlist_reads_the_last_two_fields(config, client):
     fake = client(playback=track_playback())
 
     screens.play_track_in_playlist(
-        config, ['Intro', 'Reprise', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
+        state, ['Intro', 'Reprise', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
     )
 
     kwargs = fake.named('start_playback')[0][1]
@@ -438,48 +441,48 @@ def test_play_track_in_playlist_reads_the_last_two_fields(config, client):
     assert kwargs['offset'] == {'uri': 'spotify:track:track-1'}
 
 
-def test_play_track_in_playlist_redirects_when_there_is_no_device(config, client):
+def test_play_track_in_playlist_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
 
-    result = screens.play_track_in_playlist(config, ['Song', 'pl-1', 'track-1'])
+    result = screens.play_track_in_playlist(state, ['Song', 'pl-1', 'track-1'])
 
     assert result == ('list_devices',)
     assert fake.named('start_playback') == []
 
 
-def test_the_device_redirect_round_trips_back_to_the_original_screen(config, client):
+def test_the_device_redirect_round_trips_back_to_the_original_screen(state, client):
     """
-    The whole point of recording last_screen: picking a device has to resume
-    what the user was actually trying to do.
+    The whole point of recording the pending screen: picking a device has to
+    resume what the user was actually trying to do.
     """
     props = ['Song', 'Album', 'A', 'Road Trip', 'pl-1', 'track-1']
     client(playback=None)
 
-    assert screens.play_track(config, props) == ('list_devices',)
+    assert screens.play_track(state, props) == ('list_devices',)
 
     fake = client()
-    assert screens.device_actions(config, 'd1') == ('play_track', props)
+    assert screens.device_actions(state, 'd1') == ('play_track', props)
     assert fake.named('transfer_playback') == [('transfer_playback', 'd1')]
     # The redirect state is consumed, so a later visit goes home instead.
-    assert 'last_screen' not in config
-    assert screens.device_actions(config, 'd1') == ('home_screen',)
+    assert state.pending_screen is None
+    assert screens.device_actions(state, 'd1') == ('home_screen',)
 
 
-def test_the_device_redirect_round_trips_resume(config, client):
+def test_the_device_redirect_round_trips_resume(state, client):
     client(playback=None)
 
-    assert screens.resume(config) == ('list_devices',)
+    assert screens.resume(state) == ('list_devices',)
 
     client()
-    assert screens.device_actions(config, 'd1') == ('resume',)
+    assert screens.device_actions(state, 'd1') == ('resume',)
 
 
 # --- update_cache ------------------------------------------------------------
 
 
-def test_update_cache_screen_delegates_and_returns_home(config, monkeypatch):
+def test_update_cache_screen_delegates_and_returns_home(state, monkeypatch):
     calls = []
     monkeypatch.setattr(screens.spotify, 'update_cache', lambda cfg: calls.append(cfg))
 
-    assert screens.update_cache(config) == ('home_screen',)
-    assert calls == [config]
+    assert screens.update_cache(state) == ('home_screen',)
+    assert calls == [state.config]

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -2,7 +2,13 @@ import json
 import os
 import threading
 
-from spotifz.spotify.sink import sink_all_tracks
+from spotifz.spotify.sink import (
+    SEPARATOR,
+    TRACK_ID_FIELD,
+    format_track_line,
+    parse_track_line,
+    sink_all_tracks,
+)
 
 
 def write_playlist(playlist_dir, playlist_id, name, tracks):
@@ -34,7 +40,7 @@ def make_fifo(config):
     return fifo_path
 
 
-def test_sinks_a_six_field_line_per_track(config, playlist_dir, make_track):
+def test_sinks_a_display_and_two_ids_per_track(config, playlist_dir, make_track):
     write_playlist(
         playlist_dir,
         'pl-1',
@@ -44,10 +50,10 @@ def test_sinks_a_six_field_line_per_track(config, playlist_dir, make_track):
 
     lines = drain(config, make_fifo(config))
 
-    assert lines == ['Song One :: Album :: A, B :: Road Trip :: pl-1 :: track-1']
-    # The preview pane's `awk -F " :: " '{print $6}'` depends on the id being
-    # the sixth field.
-    assert lines[0].split(' :: ')[5] == 'track-1'
+    assert lines == ['Song One :: Album :: A, B :: Road Trip\x1ftrack-1\x1fpl-1']
+    # The preview pane's `{2}` placeholder depends on the id being the second
+    # SEPARATOR-separated field.
+    assert lines[0].split(SEPARATOR)[TRACK_ID_FIELD - 1] == 'track-1'
 
 
 def test_sinks_every_track_of_every_playlist(config, playlist_dir, make_track):
@@ -61,7 +67,7 @@ def test_sinks_every_track_of_every_playlist(config, playlist_dir, make_track):
 
     lines = drain(config, make_fifo(config))
 
-    assert sorted(line.split(' :: ')[5] for line in lines) == ['a', 'b', 'c']
+    assert sorted(parse_track_line(line).track_id for line in lines) == ['a', 'b', 'c']
 
 
 def test_sinks_playlists_regardless_of_characters_in_the_id(
@@ -83,7 +89,7 @@ def test_sinks_playlists_regardless_of_characters_in_the_id(
 
     lines = drain(config, make_fifo(config))
 
-    assert sorted(line.split(' :: ')[4] for line in lines) == [
+    assert sorted(parse_track_line(line).playlist_id for line in lines) == [
         'endsinj',
         'endsinn',
         'endsino',
@@ -118,13 +124,13 @@ def test_a_broken_pipe_is_swallowed(config, playlist_dir, make_track):
         reader.join()
 
 
-def test_names_containing_the_separator_shift_the_fields(
+def test_names_containing_the_display_separator_do_not_shift_the_fields(
     config, playlist_dir, make_track
 ):
     """
-    Documents the bug rather than asserting it is fixed: ' :: ' is not
-    escaped, so a name containing it produces seven fields and pushes the id
-    out of position six. Invert this test when the separator is replaced.
+    ' :: ' is decoration inside the display field now, so a name may contain
+    it. This test used to document the opposite: it asserted seven fields and
+    an id pushed out of position six, which is what broke the preview pane.
     """
     write_playlist(
         playlist_dir,
@@ -134,9 +140,53 @@ def test_names_containing_the_separator_shift_the_fields(
     )
 
     lines = drain(config, make_fifo(config))
-    fields = lines[0].split(' :: ')
+    fields = lines[0].split(SEPARATOR)
 
-    assert len(fields) == 7
-    assert fields[5] != 'track-1'
-    # The negative index that screens.py relies on still finds it.
-    assert fields[-1] == 'track-1'
+    assert len(fields) == 3
+    # The positive index works now -- that is the whole point.
+    assert fields[TRACK_ID_FIELD - 1] == 'track-1'
+    # And the name survives intact in the display.
+    assert fields[0].startswith('Intro :: Reprise')
+
+
+def test_format_track_line_removes_a_separator_from_a_name(make_track):
+    """
+    SEPARATOR cannot occur in a real Spotify name, but the line protocol should
+    not depend on that being true.
+    """
+    track = make_track(name='Side A\x1fSide B', track_id='track-1')
+
+    line = format_track_line(track, {'id': 'pl-1', 'name': 'Mix'})
+
+    assert len(line.rstrip('\n').split(SEPARATOR)) == 3
+    assert parse_track_line(line.rstrip('\n')).track_id == 'track-1'
+
+
+def test_format_track_line_removes_a_newline_from_a_name(make_track):
+    """One record is one line, so a name may not end it early."""
+    track = make_track(name='First\nSecond', track_id='track-1')
+
+    line = format_track_line(track, {'id': 'pl-1', 'name': 'Mix'})
+
+    assert line.count('\n') == 1
+    assert line.endswith('\n')
+
+
+def test_parse_track_line_round_trips_what_format_wrote(make_track):
+    """
+    Pins the writer and the reader to each other. Their drifting apart -- one
+    joining on ' :: ', the other splitting on '::' -- is what item 7 was.
+    """
+    track = make_track(name='Song :: One', track_id='track-1', artists=('A', 'B'))
+
+    ref = parse_track_line(
+        format_track_line(track, {'id': 'pl-1', 'name': 'Road Trip'}).rstrip('\n')
+    )
+
+    assert ref.track_id == 'track-1'
+    assert ref.playlist_id == 'pl-1'
+    # The full name survives on the line and in the display...
+    assert ref.display.startswith('Song :: One')
+    # ...but `name` is prompt decoration and stops at the display separator.
+    # Cosmetic, and the only thing ' :: ' in a name still affects.
+    assert ref.name == 'Song'

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,140 @@
+import json
+import os
+import shutil
+
+from spotifz.state import PERSISTED_FIELDS, AppState
+
+
+def raw_config(cache_path):
+    """A config as it comes out of the JSON file, before normalisation."""
+    return {
+        'spotify_client': {
+            'client_id': 'client-id',
+            'client_secret': 'client-secret',
+            'redirect_uri': 'http://127.0.0.1:8080/',
+        },
+        'cache_path': cache_path,
+        'user': 'tester',
+    }
+
+
+def test_from_config_leaves_the_callers_dict_alone(tmp_path):
+    """
+    The core claim of the item: loading state must not turn the user's config
+    into a scratchpad.
+    """
+    cfg = raw_config(str(tmp_path / 'cache'))
+    before = json.dumps(cfg, sort_keys=True)
+
+    AppState.from_config(cfg)
+
+    assert json.dumps(cfg, sort_keys=True) == before
+
+
+def test_from_config_normalises_the_config_on_its_own_copy(monkeypatch, tmp_path):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    cfg = raw_config('~/.cache/spotifz')
+
+    state = AppState.from_config(cfg)
+
+    assert state.cache_path == str(tmp_path / '.cache/spotifz')
+    base = os.path.join(state.cache_path, 'spotify_data')
+    assert state.data_paths['base_path'] == base
+    assert state.data_paths['playlist_path'] == os.path.join(base, 'playlists')
+
+
+def test_the_active_device_survives_into_the_next_session(tmp_path):
+    """
+    The user-facing payoff: the device chosen this run is still chosen next run.
+    """
+    cfg = raw_config(str(tmp_path / 'cache'))
+    AppState.from_config(cfg).set_active_device('d1')
+
+    assert AppState.from_config(cfg).active_device_id == 'd1'
+
+
+def test_no_state_file_yet_means_no_active_device(tmp_path):
+    state = AppState.from_config(raw_config(str(tmp_path / 'cache')))
+
+    assert state.active_device_id is None
+
+
+def test_a_corrupt_state_file_is_ignored(tmp_path):
+    """
+    A run killed mid-write must not stop the app from launching at all.
+    """
+    cfg = raw_config(str(tmp_path / 'cache'))
+    state = AppState.from_config(cfg)
+    os.makedirs(state.cache_path, exist_ok=True)
+    with open(state.state_path, 'w') as ofile:
+        ofile.write('{not json')
+
+    assert AppState.from_config(cfg).active_device_id is None
+
+
+def test_a_state_file_of_the_wrong_shape_is_ignored(tmp_path):
+    cfg = raw_config(str(tmp_path / 'cache'))
+    state = AppState.from_config(cfg)
+    os.makedirs(state.cache_path, exist_ok=True)
+    with open(state.state_path, 'w') as ofile:
+        json.dump(['not', 'a', 'dict'], ofile)
+
+    assert AppState.from_config(cfg).active_device_id is None
+
+
+def test_save_writes_exactly_the_persisted_fields(tmp_path):
+    """
+    The guard that lets a non-serialisable field (a database connection, an API
+    client) be added to AppState without silently breaking save().
+    """
+    state = AppState.from_config(raw_config(str(tmp_path / 'cache')))
+    state.set_active_device('d1')
+
+    with open(state.state_path) as ifile:
+        written = json.load(ifile)
+
+    assert sorted(written) == sorted(PERSISTED_FIELDS)
+
+
+def test_the_pending_screen_is_not_persisted(tmp_path):
+    """
+    Resuming last week's half-finished navigation on startup would be wrong.
+    """
+    cfg = raw_config(str(tmp_path / 'cache'))
+    state = AppState.from_config(cfg)
+    state.pending_screen = ('resume', ())
+    state.save()
+
+    assert AppState.from_config(cfg).pending_screen is None
+
+
+def test_save_leaves_no_temporary_file_behind(tmp_path):
+    state = AppState.from_config(raw_config(str(tmp_path / 'cache')))
+    state.set_active_device('d1')
+
+    assert os.listdir(state.cache_path) == [os.path.basename(state.state_path)]
+
+
+def test_the_state_file_survives_a_cache_update(tmp_path):
+    """
+    `spotifz -U` rmtree's data_paths['base_path'] wholesale. Keeping the state
+    file outside that directory is the only reason the device is not forgotten
+    on every cache update.
+    """
+    cfg = raw_config(str(tmp_path / 'cache'))
+    state = AppState.from_config(cfg)
+    state.set_active_device('d1')
+    os.makedirs(state.data_paths['playlist_path'], exist_ok=True)
+
+    shutil.rmtree(state.data_paths['base_path'])
+
+    assert os.path.exists(state.state_path)
+    assert AppState.from_config(cfg).active_device_id == 'd1'
+
+
+def test_taking_the_pending_screen_consumes_it(tmp_path):
+    state = AppState.from_config(raw_config(str(tmp_path / 'cache')))
+    state.pending_screen = ('play_track', (['Song'],))
+
+    assert state.take_pending_screen() == ('play_track', (['Song'],))
+    assert state.take_pending_screen() is None


### PR DESCRIPTION
Structural refactor. Five commits, each independently green.

## Runtime state out of the config dict

The `config` dict was doubling as a scratchpad: `update_data_paths` injected derived paths into it, `device_actions` wrote `active_device_id`, `_redirect_to_devices` wrote `last_screen`/`last_screen_args`. Nothing distinguished a user setting from something the app discovered while running, and the discovered things were never persisted.

`AppState` (new `spotifz/state.py`) owns the session. It normalises the config onto a copy, so the caller's dict is never written to, and persists `active_device_id` to `<cache_path>/{user}_state.json`.

**The user-visible payoff:** the playback device chosen this session survives into the next one, instead of having to be re-picked every time.

Details worth reviewing:

- The state file is named after the user, like the OAuth token cache beside it, and sits **outside** `spotify_data/` — which `update_cache` deletes wholesale. Putting it under `data_paths` would silently reset the device on every `spotifz -U`. A test pins this.
- Persistence is an explicit `PERSISTED_FIELDS` whitelist rather than `asdict()`, so a field holding a live handle can be added later without becoming a serialisation problem. A test pins the written file's keys to enforce that.
- Writes go through a temporary file and `os.replace`, so a run killed mid-write cannot leave a state file that breaks the next launch.
- `data_paths` deliberately **stays** in `state.config`. It is derived configuration, not runtime state, so moving it would push `AppState` through auth, client, storage, sink and fzf for no behavioural gain. `storage.py` and `update_data_paths` are untouched.
- Persisting the device introduces a failure mode that could not happen before: read off disk, the id may be a device switched off a week ago, and Spotify answers `start_playback` with a 404 that `cli.main` does not catch. `_start_playback` forgets the device and redirects, so the user lands on the device picker — the same path as never having chosen one — rather than on a traceback.

## The ` :: ` separator was ambiguous

The candidate line was six ` :: `-joined fields with no escaping, so a track, album or playlist name containing ` :: ` shifted every field after it. `screens.py` survived by addressing the ids from the end; the preview pane's `awk '{print $6}'` did not, and for those tracks read the playlist id as a filename and silently showed nothing.

The line is now `<display>\x1f<track_id>\x1f<playlist_id>`, where `<display>` is the same four ` :: `-joined fields as before, byte for byte. `0x1f` cannot occur in a name, and `_clean` removes it (and newlines) regardless, so the field count is fixed at three.

**`awk` is deleted rather than fixed.** fzf is told the structure — `--delimiter '\x1f' --with-nth 1` — and does the extraction itself via its own `{2}` placeholder. The separator never reaches a shell.

The format now has one owner: `sink.py` holds the constants, a `TrackRef` and the formatter/parser pair, re-exported from `spotifz.spotify`. `screens` and `fzf` import them instead of each re-encoding the layout by hand, which is how the writer and reader came to disagree in the first place. The negative-index addressing in `screens.py` is gone — it existed only to survive the ambiguity.

### Three latent bugs fixed in passing

- **The preview pane has been broken on any machine without a bare `python` on PATH** — current macOS and most Linux distributions ship only `python3`. fzf runs the command, gets nothing, and reports nothing. Now `sys.executable`.
- The track directory was interpolated unquoted and piped through `xargs`, which splits on whitespace, so a `cache_path` containing a space fed `json.tool` two truncated filenames.
- `0x1f` is whitespace to Python, so `run_fzf_sink`'s bare `.strip()` would have eaten a separator beside an empty field. It strips newlines only.

Neither of the first two could be caught, because **nothing in the suite ever executed the preview command** — the existing test asserted substrings of the command string. `1d863e8` makes `preview_command` a function and adds tests that actually run it, deliberately landing *before* the format change.

## Behaviour changes to be aware of

- `--with-nth 1` removes the ids from fzf's **match** text, not just the display. Better search quality — base62 noise can no longer collide with a query — but a pasted track id will no longer match.
- `TrackRef.name` truncates at ` :: ` for the fzf prompt. Cosmetic, and the only thing a ` :: ` in a name still affects.
- `_redirect_to_devices` now also fires on a dead device, not only a missing one.

## Tests

Two tests turn around rather than being dropped. `test_sink.py`'s separator test documented the bug — seven fields and a displaced id — and now asserts three fields and that the *positive* index finds it. The preview test added in `1d863e8` asserted that a ` :: ` name renders nothing, and now asserts the JSON renders.

`test_play_track_in_playlist_reads_the_last_two_fields` is reframed rather than deleted, following the precedent in `867f6fd`: the negative indices it pinned are gone, but its durable claim — a name containing ` :: ` still plays the right track — is exactly what this PR makes true.

Every new guard was watched failing before being kept:

| Reverted | Result |
| --- | --- |
| `save()` removed from `set_active_device` | round-trip test fails, `assert None == 'd1'` |
| `from_config` normalises in place | both no-mutation tests fail |
| the `try/except SpotifyException` | both stale-device tests fail with the traceback |
| `sys.executable` → a bad interpreter | 2 executing preview tests fail |
| the track dir unquoted | the space-in-path test fails |
| `SEPARATOR` changed, preview not updated | 4 tests fail |
| writer joined on the wrong separator | 6 tests fail |

## Verification

115 tests pass on 3.13 and on the 3.9 floor; `ruff check`, `ruff format --check` and all six pre-commit hooks pass; `uv run --locked` holds, with no dependency change and no `uv.lock` edit. `spotifz --help` works.

Beyond the suite, the whole item-7 pipeline was driven against the real `fzf` 0.74.1 binary under a pty, with a space in the preview path — the display renders `Intro :: Reprise :: Album :: A, B :: Road Trip` with no control characters, the preview pane renders that track's JSON (the case that was broken), and fzf prints the full line including the ids on accept.

**One note for anyone verifying the 3.9 leg locally:** `uv run --python 3.9 --isolated --with pytest --with . pytest -q` can serve a **stale cached build** and pass against old code. Neither `--reinstall-package`, `--refresh-package`, `uv cache clean spotifz` nor deleting `build/` evicts it. Use `--with-editable .` — there is no wheel to go stale. CI is unaffected, since it builds from a fresh checkout.