### PR TITLE
Show the current queue, and add to it from the search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Home Screen:
 3. [x] Update Cache
 4. [x] Play/Pause
 5. [x] Search My Library
-6. [ ] Current Queue
+6. [x] Current Queue
 
 Selected Track:
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Selected Track:
 
 1. [x] Play track in playlist
 2. [x] Play track
+3. [x] Add to Queue
 
 ## TODO
 

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -98,6 +98,73 @@ def describe_playback(playback):
     return lines
 
 
+# 'Now' is the widest marker the numbered rows line up against.
+QUEUE_NOW = 'Now'
+UNKNOWN_ITEM = 'unknown item'
+
+
+def _one_line(value):
+    """
+    run_fzf joins the candidates with newlines, so a name carrying one would
+    arrive as a row of its own.
+    """
+    return ' '.join(str(value if value is not None else '').split())
+
+
+def _artist_names(item):
+    names = (_one_line(artist.get('name')) for artist in item.get('artists') or [])
+    return ', '.join(name for name in names if name)
+
+
+def describe_queue_item(item):
+    """
+    One queued item, read in the same order as a search result: what it is,
+    what it came from, who made it.
+    """
+    if item.get('type') == 'episode' or item.get('show') is not None:
+        # Episodes carry show/publisher rather than album/artists.
+        show = item.get('show') or {}
+        parts = [item.get('name'), show.get('name'), show.get('publisher')]
+    else:
+        parts = [
+            item.get('name'),
+            (item.get('album') or {}).get('name'),
+            _artist_names(item),
+        ]
+    row = spotify.DISPLAY_SEPARATOR.join(part for part in map(_one_line, parts) if part)
+    # A row naming nothing at all still occupies a numbered slot, so it says so
+    # rather than trailing off after the number.
+    return row or UNKNOWN_ITEM
+
+
+def describe_queue(queue):
+    """
+    Builds the display rows for the queue: what is playing now, then what
+    follows it, in order. Returns an empty list when there is nothing to show.
+    """
+    if not queue:
+        # With no active device Spotify answers 204, which arrives as None:
+        # there is no queue, rather than an empty one.
+        return []
+
+    rows = []
+    now_playing = queue.get('currently_playing')
+    if now_playing is not None:
+        rows.append((QUEUE_NOW, now_playing))
+    # Numbered over the items that survive, so a marker is a position in the
+    # list on screen and the count never skips.
+    upcoming = [item for item in queue.get('queue') or [] if item is not None]
+    rows.extend((str(position), item) for position, item in enumerate(upcoming, 1))
+    if not rows:
+        return []
+
+    marker_width = max(len(marker) for marker, _ in rows)
+    return [
+        '{}  {}'.format(marker.rjust(marker_width), describe_queue_item(item))
+        for marker, item in rows
+    ]
+
+
 def current_playback(state):
     sp = spotify.get_spotify_client(state.config)
     # Without `additional_types`, Spotify represents an unsupported item type

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -24,14 +24,15 @@ def _resolve_device(state, playback):
     return state.active_device_id
 
 
-def _start_playback(state, sp, **kwargs):
+def _player_command(state, command, **kwargs):
     """
-    A device that was alive last session may be gone this one, and Spotify
-    answers with a 404. Forget it, so the caller can send the user to pick
-    another -- the same path as never having chosen one.
+    Runs one command against the player. A device that was alive last session
+    may be gone this one, and Spotify answers with a 404. Forget it, so the
+    caller can send the user to pick another -- the same path as never having
+    chosen one.
     """
     try:
-        sp.start_playback(**kwargs)
+        command(**kwargs)
     except SpotifyException:
         state.forget_active_device()
         return False
@@ -243,8 +244,8 @@ def resume(state):
     playback = sp.current_playback()
     if playback is None:
         device_id = _resolve_device(state, playback)
-        started = device_id is not None and _start_playback(
-            state, sp, device_id=device_id
+        started = device_id is not None and _player_command(
+            state, sp.start_playback, device_id=device_id
         )
         if not started:
             return _redirect_to_devices(state, 'resume')
@@ -274,6 +275,7 @@ def track_actions(_, track):
     choices = {
         'Play Track in Playlist': 'play_track_in_playlist',
         'Play Track': 'play_track',
+        'Add to Queue': 'add_to_queue',
     }
 
     track_name = track.name.replace("'", '')
@@ -291,9 +293,9 @@ def track_actions(_, track):
 def play_track_in_playlist(state, track):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
-    started = device_id is not None and _start_playback(
+    started = device_id is not None and _player_command(
         state,
-        sp,
+        sp.start_playback,
         device_id=device_id,
         context_uri=f'spotify:playlist:{track.playlist_id}',
         offset={'uri': f'spotify:track:{track.track_id}'},
@@ -306,9 +308,30 @@ def play_track_in_playlist(state, track):
 def play_track(state, track):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
-    started = device_id is not None and _start_playback(
-        state, sp, device_id=device_id, uris=[f'spotify:track:{track.track_id}']
+    started = device_id is not None and _player_command(
+        state,
+        sp.start_playback,
+        device_id=device_id,
+        uris=[f'spotify:track:{track.track_id}'],
     )
     if not started:
         return _redirect_to_devices(state, 'play_track', track)
+    return ('search',)
+
+
+def add_to_queue(state, track):
+    """
+    Appends to the queue, so tracks can be stacked one after another without
+    leaving the results -- which is why this returns to the search.
+    """
+    sp = spotify.get_spotify_client(state.config)
+    device_id = _resolve_device(state, sp.current_playback())
+    queued = device_id is not None and _player_command(
+        state,
+        sp.add_to_queue,
+        uri=f'spotify:track:{track.track_id}',
+        device_id=device_id,
+    )
+    if not queued:
+        return _redirect_to_devices(state, 'add_to_queue', track)
     return ('search',)

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -45,6 +45,7 @@ def home_screen(_):
         '[ 3 ] Devices': 'list_devices',
         '[ 4 ] Play/Pause': 'resume',
         '[ 5 ] Update Cache': 'update_cache',
+        '[ 6 ] Current Queue': 'current_queue',
     }
     chosen = fzf.run_fzf(list(choices.keys()), prompt='[Home] > ')[0]
     if chosen == '':
@@ -176,6 +177,21 @@ def current_playback(state):
         return ('home_screen',)
 
     fzf.run_fzf(lines, prompt='Playback > ')[0]
+    return ('home_screen',)
+
+
+def current_queue(state):
+    """
+    Read-only: Spotify can append to the queue and skip one track at a time,
+    but has no way to jump to a chosen position in it, so there is nothing
+    honest for a selection here to do.
+    """
+    sp = spotify.get_spotify_client(state.config)
+    rows = describe_queue(sp.queue())
+    if not rows:
+        return ('home_screen',)
+
+    fzf.run_fzf(rows, prompt='[Queue] > ')
     return ('home_screen',)
 
 

--- a/spotifz/spotify/__init__.py
+++ b/spotifz/spotify/__init__.py
@@ -2,6 +2,7 @@ from .client import get_spotify_client  # noqa: F401
 from .sink import (  # noqa: F401
     ADDED_AT_FIELD,
     DISPLAY_FIELD,
+    DISPLAY_SEPARATOR,
     PLAYLIST_ID_FIELD,
     PLAYLIST_NAME_FIELD,
     SEPARATOR,

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -192,6 +192,117 @@ def test_describe_playback_omits_a_missing_device():
     ]
 
 
+def queue_item(name='Song', album='Album', artists=('A', 'B')):
+    return {
+        'type': 'track',
+        'name': name,
+        'album': {'name': album},
+        'artists': [{'name': artist} for artist in artists],
+    }
+
+
+# --- describe_queue ----------------------------------------------------------
+
+
+def test_describe_queue_says_nothing_without_a_queue():
+    """No active device answers 204, which spotipy hands back as None."""
+    assert screens.describe_queue(None) == []
+
+
+def test_describe_queue_says_nothing_when_the_queue_is_empty():
+    assert screens.describe_queue({'currently_playing': None, 'queue': []}) == []
+
+
+def test_describe_queue_marks_what_is_playing_and_numbers_what_follows():
+    queue = {
+        'currently_playing': queue_item('Song A'),
+        'queue': [queue_item('Song B'), queue_item('Song C')],
+    }
+
+    assert screens.describe_queue(queue) == [
+        'Now  Song A :: Album :: A, B',
+        '  1  Song B :: Album :: A, B',
+        '  2  Song C :: Album :: A, B',
+    ]
+
+
+def test_describe_queue_numbers_from_one_when_nothing_is_playing():
+    queue = {'currently_playing': None, 'queue': [queue_item('Song B')]}
+
+    assert screens.describe_queue(queue) == ['1  Song B :: Album :: A, B']
+
+
+def test_describe_queue_lines_up_two_digit_positions():
+    """
+    The markers are a column, not a prefix: ragged numbers push every title to
+    a different indent and the pane stops being scannable.
+    """
+    queue = {'currently_playing': None, 'queue': [queue_item() for _ in range(10)]}
+
+    rows = screens.describe_queue(queue)
+
+    assert rows[0].startswith(' 1  Song')
+    assert rows[9].startswith('10  Song')
+
+
+def test_describe_queue_renders_an_episode():
+    queue = {
+        'currently_playing': None,
+        'queue': [
+            {
+                'type': 'episode',
+                'name': 'Episode One',
+                'show': {'name': 'The Show', 'publisher': 'A Publisher'},
+            }
+        ],
+    }
+
+    assert screens.describe_queue(queue) == ['1  Episode One :: The Show :: A Publisher']
+
+
+def test_describe_queue_recognises_an_episode_by_its_show_alone():
+    """Not every episode payload carries type == 'episode'."""
+    item = {'name': 'Episode One', 'show': {'name': 'The Show'}}
+
+    assert screens.describe_queue_item(item) == 'Episode One :: The Show'
+
+
+def test_describe_queue_omits_a_missing_album_and_artists():
+    item = {'type': 'track', 'name': 'Song', 'album': None, 'artists': []}
+
+    assert screens.describe_queue_item(item) == 'Song'
+
+
+def test_describe_queue_names_an_item_it_cannot_describe():
+    """The row still holds a numbered slot, so it may not trail off blank."""
+    assert screens.describe_queue_item({'type': 'track'}) == 'unknown item'
+
+
+def test_describe_queue_keeps_one_item_on_one_row():
+    """
+    run_fzf joins the candidates with newlines, so a name carrying one would
+    otherwise arrive as an extra row that selects nothing.
+    """
+    queue = {'currently_playing': None, 'queue': [queue_item('Song\nB')]}
+
+    rows = screens.describe_queue(queue)
+
+    assert rows == ['1  Song B :: Album :: A, B']
+
+
+def test_describe_queue_does_not_skip_a_number_for_an_unrenderable_entry():
+    """An advert in the queue arrives as a null entry."""
+    queue = {
+        'currently_playing': None,
+        'queue': [queue_item('Song A'), None, queue_item('Song C')],
+    }
+
+    rows = screens.describe_queue(queue)
+
+    assert [row.split('  ')[0] for row in rows] == ['1', '2']
+    assert rows[1].endswith('Song C :: Album :: A, B')
+
+
 # --- current_playback --------------------------------------------------------
 
 

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -16,11 +16,14 @@ def track_ref(display, track_id='track-1', playlist_id='pl-1'):
 
 
 class FakeClient:
-    def __init__(self, playback=None, devices=(), start_error=None, queue=None):
+    def __init__(
+        self, playback=None, devices=(), start_error=None, queue=None, queue_error=None
+    ):
         self._playback = playback
         self._devices = list(devices)
         self._start_error = start_error
         self._queue = queue
+        self._queue_error = queue_error
         self.calls = []
 
     def current_playback(self, **kwargs):
@@ -43,6 +46,11 @@ class FakeClient:
         if self._start_error is not None:
             raise self._start_error
 
+    def add_to_queue(self, uri, device_id=None):
+        self.calls.append(('add_to_queue', {'uri': uri, 'device_id': device_id}))
+        if self._queue_error is not None:
+            raise self._queue_error
+
     def pause_playback(self):
         self.calls.append(('pause_playback', {}))
 
@@ -57,8 +65,10 @@ def client(monkeypatch):
     screens.spotify.get_spotify_client, so that is the only seam needed.
     """
 
-    def _install(playback=None, devices=(), start_error=None, queue=None):
-        fake = FakeClient(playback, devices, start_error, queue)
+    def _install(
+        playback=None, devices=(), start_error=None, queue=None, queue_error=None
+    ):
+        fake = FakeClient(playback, devices, start_error, queue, queue_error)
         monkeypatch.setattr(screens.spotify, 'get_spotify_client', lambda cfg: fake)
         return fake
 
@@ -698,6 +708,60 @@ def test_resume_forgets_a_persisted_device_that_no_longer_exists(state, client):
     assert screens.resume(state) == ('list_devices',)
     assert state.active_device_id is None
     assert state.pending_screen == ('resume', ())
+
+
+# --- add_to_queue ------------------------------------------------------------
+
+
+def test_track_actions_offers_queueing(state, fzf):
+    fzf('Add to Queue')
+    track = track_ref('Song :: Album :: A :: Road Trip')
+
+    assert screens.track_actions(state, track) == ('add_to_queue', track)
+
+
+def test_add_to_queue_queues_on_the_device_that_is_playing(state, client):
+    fake = client(playback=track_playback())
+
+    assert screens.add_to_queue(state, track_ref('Song')) == ('search',)
+    assert fake.named('add_to_queue') == [
+        ('add_to_queue', {'uri': 'spotify:track:track-1', 'device_id': 'device-1'})
+    ]
+
+
+def test_add_to_queue_returns_to_the_search_so_tracks_can_be_stacked(state, client):
+    """Queueing an album a track at a time is the whole point of appending."""
+    fake = client(playback=None)
+    state.active_device_id = 'd1'
+
+    assert screens.add_to_queue(state, track_ref('Song')) == ('search',)
+    assert screens.add_to_queue(state, track_ref('Other', 'track-2')) == ('search',)
+    assert [call[1]['uri'] for call in fake.named('add_to_queue')] == [
+        'spotify:track:track-1',
+        'spotify:track:track-2',
+    ]
+
+
+def test_add_to_queue_redirects_when_there_is_no_device(state, client):
+    fake = client(playback=None)
+    track = track_ref('Song')
+
+    assert screens.add_to_queue(state, track) == ('list_devices',)
+    assert fake.named('add_to_queue') == []
+    assert state.pending_screen == ('add_to_queue', (track,))
+
+
+def test_add_to_queue_forgets_a_persisted_device_that_no_longer_exists(state, client):
+    """
+    Queueing against a dead device fails the same way starting playback does,
+    so it has to recover the same way rather than tracebacking out of the app.
+    """
+    client(playback=None, queue_error=device_gone())
+    state.set_active_device('d1')
+
+    assert screens.add_to_queue(state, track_ref('Song')) == ('list_devices',)
+    assert state.active_device_id is None
+    assert AppState.from_config(state.config).active_device_id is None
 
 
 # --- update_cache ------------------------------------------------------------

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -16,10 +16,11 @@ def track_ref(display, track_id='track-1', playlist_id='pl-1'):
 
 
 class FakeClient:
-    def __init__(self, playback=None, devices=(), start_error=None):
+    def __init__(self, playback=None, devices=(), start_error=None, queue=None):
         self._playback = playback
         self._devices = list(devices)
         self._start_error = start_error
+        self._queue = queue
         self.calls = []
 
     def current_playback(self, **kwargs):
@@ -29,6 +30,10 @@ class FakeClient:
     def devices(self):
         self.calls.append(('devices', {}))
         return {'devices': self._devices}
+
+    def queue(self):
+        self.calls.append(('queue', {}))
+        return self._queue
 
     def transfer_playback(self, device_id):
         self.calls.append(('transfer_playback', device_id))
@@ -52,8 +57,8 @@ def client(monkeypatch):
     screens.spotify.get_spotify_client, so that is the only seam needed.
     """
 
-    def _install(playback=None, devices=(), start_error=None):
-        fake = FakeClient(playback, devices, start_error)
+    def _install(playback=None, devices=(), start_error=None, queue=None):
+        fake = FakeClient(playback, devices, start_error, queue)
         monkeypatch.setattr(screens.spotify, 'get_spotify_client', lambda cfg: fake)
         return fake
 
@@ -333,6 +338,48 @@ def test_current_playback_shows_the_lines(state, client, fzf):
 
     assert screens.current_playback(state) == ('home_screen',)
     assert seen['items'][0][0] == 'Track : Song'
+
+
+# --- current_queue -----------------------------------------------------------
+
+
+def test_current_queue_returns_home_without_prompting(state, client, fzf):
+    client(queue=None)
+    seen = fzf()
+
+    assert screens.current_queue(state) == ('home_screen',)
+    assert seen['items'] == []
+
+
+def test_current_queue_shows_the_rows(state, client, fzf):
+    client(
+        queue={
+            'currently_playing': queue_item('Song A'),
+            'queue': [queue_item('Song B')],
+        }
+    )
+    seen = fzf('')
+
+    assert screens.current_queue(state) == ('home_screen',)
+    assert seen['items'][0] == [
+        'Now  Song A :: Album :: A, B',
+        '  1  Song B :: Album :: A, B',
+    ]
+    assert seen['prompts'] == ['[Queue] > ']
+
+
+def test_current_queue_returns_home_whatever_is_selected(state, client, fzf):
+    """There is nothing to act on, so a selection is not a route anywhere."""
+    client(queue={'currently_playing': queue_item('Song A'), 'queue': []})
+    fzf('Now  Song A :: Album :: A, B')
+
+    assert screens.current_queue(state) == ('home_screen',)
+
+
+def test_home_screen_reaches_the_queue(state, fzf):
+    fzf('[ 6 ] Current Queue')
+
+    assert screens.home_screen(state) == ('current_queue',)
 
 
 # --- devices -----------------------------------------------------------------


### PR DESCRIPTION
Ticks the last unchecked home-screen box. Reading the queue and adding to it land together — a queue you can only look at is half a feature.

- [x] Render the queue as one row per item
- [x] Show the current queue from the home screen (`[ 6 ]`)
- [x] Queue a track from the search results (`Add to Queue`)

```
[Queue] >
  Now  Bohemian Rhapsody :: A Night at the Opera :: Queen
    1  You're My Best Friend :: A Night at the Opera :: Queen
    2  The Rest Is History: Rome :: The Rest Is History :: Goalhanger
```

**Read-only by API constraint.** Spotify can append to the queue and skip one track, but cannot jump to a position in it — the only fakes are N `next_track` calls, or `start_playback(uris=[...])`, which discards everything queued behind it. So a selection returns home, and the write half lives where it works: `Add to Queue` returns to the search, so an album can be stacked a track at a time.

**No new OAuth scopes** — the existing two already cover both endpoints, so nobody re-authorizes. No cache or state format changes.

**One refactor:** `_start_playback` → `_player_command`, taking the bound method rather than the client. Queueing hits the same dead-device 404 as playback and now recovers the same way (forget device → picker → resume). The three existing playback paths are unchanged.

Out of scope: reordering or removing queued items (no endpoint exists), and a preview pane for queue rows (the preview is wired to the sink's candidate-line format).

**Testing:** 193 pass, 43 new — rendering (episodes, marker alignment past nine, a newline in a name, nulls not skipping a number), the screen's empty and return-home paths, and queueing (device redirect, dead device forgotten on disk). `ruff check` and `ruff format --check` clean.

