### PR TITLE
Dispatch screens through an explicit registry

### DIFF
--- a/spotifz/__init__.py
+++ b/spotifz/__init__.py
@@ -57,7 +57,9 @@ def launch(config):
     state = prepare(config)
     ensure_fzf()
 
-    choice, *screen_args = screens.home_screen(state)
+    # The entry point resolves through the registry like every other hop, so
+    # home_screen is not a second, hard-coded way to name a screen.
+    choice, screen_args = 'home_screen', []
     while choice is not None:
-        upcoming_screen = getattr(screens, choice)
+        upcoming_screen = screens.get_screen(choice)
         choice, *screen_args = upcoming_screen(state, *screen_args)

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -6,6 +6,43 @@ from .. import spotify
 from ..helpers import fzf
 
 
+class UnknownScreen(LookupError):
+    """
+    A screen returned a name nothing is registered under. Always a bug in this
+    repo -- a screen name is never user input and is never read from disk -- so
+    it is deliberately not caught in cli.main, which would swallow the
+    traceback that says which name. LookupError rather than KeyError, whose
+    __str__ reprs the message and would print it wrapped in quotes.
+    """
+
+
+# Name -> screen. Registration is an import side effect, which is why the
+# registry lives beside the screens rather than in a module of its own: a
+# separate module could be imported before them and answer lookups from a
+# legitimately empty dict.
+SCREENS = {}
+
+
+def screen(fn):
+    """
+    Marks a function as reachable as a destination from another screen. The
+    key is the function's own name, so the strings the screens already return
+    stay the contract and cannot drift from the definitions.
+    """
+    SCREENS[fn.__name__] = fn
+    return fn
+
+
+def get_screen(name):
+    try:
+        return SCREENS[name]
+    except KeyError:
+        raise UnknownScreen(
+            '{!r} is not a registered screen. Screens are the functions '
+            'decorated with @screen in {}.'.format(name, __name__)
+        ) from None
+
+
 def _redirect_to_devices(state, screen, *screen_args):
     """
     Send the user to device selection, recording where to return afterwards.
@@ -58,6 +95,7 @@ TRACK_ACTIONS_CHOICES = {
 }
 
 
+@screen
 def home_screen(_):
     chosen = fzf.run_fzf(list(HOME_CHOICES.keys()), prompt='[Home] > ')[0]
     if chosen == '':
@@ -178,6 +216,7 @@ def describe_queue(queue):
     ]
 
 
+@screen
 def current_playback(state):
     sp = spotify.get_spotify_client(state.config)
     # Without `additional_types`, Spotify represents an unsupported item type
@@ -192,6 +231,7 @@ def current_playback(state):
     return ('home_screen',)
 
 
+@screen
 def current_queue(state):
     """
     Read-only: Spotify can append to the queue and skip one track at a time,
@@ -207,6 +247,7 @@ def current_queue(state):
     return ('home_screen',)
 
 
+@screen
 def list_devices(state):
     devices = sp_devices(state)
     chosen = fzf.run_fzf(list(devices.keys()), prompt='[Devices] > ')[0]
@@ -236,6 +277,7 @@ def sp_devices(state):
     return labelled
 
 
+@screen
 def device_actions(state, device_id):
     """
     For now, there is just one action
@@ -250,6 +292,7 @@ def device_actions(state, device_id):
     return ('home_screen',)
 
 
+@screen
 def resume(state):
     sp = spotify.get_spotify_client(state.config)
     playback = sp.current_playback()
@@ -267,11 +310,13 @@ def resume(state):
     return ('home_screen',)
 
 
+@screen
 def update_cache(state):
     spotify.update_cache(state.config)
     return ('home_screen',)
 
 
+@screen
 def search(state):
     chosen = fzf.run_fzf_sink(
         spotify.sink_all_tracks, state.config, prompt='[Search] > '
@@ -282,6 +327,7 @@ def search(state):
     return 'track_actions', spotify.parse_track_line(chosen)
 
 
+@screen
 def track_actions(_, track):
     track_name = track.name.replace("'", '')
     if len(track_name) > 20:
@@ -295,6 +341,7 @@ def track_actions(_, track):
     return TRACK_ACTIONS_CHOICES[chosen], track
 
 
+@screen
 def play_track_in_playlist(state, track):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
@@ -310,6 +357,7 @@ def play_track_in_playlist(state, track):
     return ('search',)
 
 
+@screen
 def play_track(state, track):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
@@ -324,6 +372,7 @@ def play_track(state, track):
     return ('search',)
 
 
+@screen
 def add_to_queue(state, track):
     """
     Appends to the queue, so tracks can be stacked one after another without

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -43,11 +43,11 @@ def get_screen(name):
         ) from None
 
 
-def _redirect_to_devices(state, screen, *screen_args):
+def _redirect_to_devices(state, screen_name, *screen_args):
     """
     Send the user to device selection, recording where to return afterwards.
     """
-    state.pending_screen = (screen, screen_args)
+    state.pending_screen = (screen_name, screen_args)
     return ('list_devices',)
 
 
@@ -287,8 +287,8 @@ def device_actions(state, device_id):
     state.set_active_device(device_id)
     pending = state.take_pending_screen()
     if pending is not None:
-        screen, screen_args = pending
-        return (screen, *screen_args)
+        screen_name, screen_args = pending
+        return (screen_name, *screen_args)
     return ('home_screen',)
 
 

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -39,19 +39,30 @@ def _player_command(state, command, **kwargs):
     return True
 
 
+# Menu label -> the screen it dispatches to. Module-level rather than local so
+# a test can check every destination against the registry: a misspelled name
+# here would otherwise only surface as a failed lookup after fzf has exited.
+HOME_CHOICES = {
+    '[ 1 ] Search Library': 'search',
+    '[ 2 ] Current Playback': 'current_playback',
+    '[ 3 ] Devices': 'list_devices',
+    '[ 4 ] Play/Pause': 'resume',
+    '[ 5 ] Update Cache': 'update_cache',
+    '[ 6 ] Current Queue': 'current_queue',
+}
+
+TRACK_ACTIONS_CHOICES = {
+    'Play Track in Playlist': 'play_track_in_playlist',
+    'Play Track': 'play_track',
+    'Add to Queue': 'add_to_queue',
+}
+
+
 def home_screen(_):
-    choices = {
-        '[ 1 ] Search Library': 'search',
-        '[ 2 ] Current Playback': 'current_playback',
-        '[ 3 ] Devices': 'list_devices',
-        '[ 4 ] Play/Pause': 'resume',
-        '[ 5 ] Update Cache': 'update_cache',
-        '[ 6 ] Current Queue': 'current_queue',
-    }
-    chosen = fzf.run_fzf(list(choices.keys()), prompt='[Home] > ')[0]
+    chosen = fzf.run_fzf(list(HOME_CHOICES.keys()), prompt='[Home] > ')[0]
     if chosen == '':
         return (None,)
-    return (choices[chosen],)
+    return (HOME_CHOICES[chosen],)
 
 
 def describe_playback(playback):
@@ -272,22 +283,16 @@ def search(state):
 
 
 def track_actions(_, track):
-    choices = {
-        'Play Track in Playlist': 'play_track_in_playlist',
-        'Play Track': 'play_track',
-        'Add to Queue': 'add_to_queue',
-    }
-
     track_name = track.name.replace("'", '')
     if len(track_name) > 20:
         prompt = f'[{track_name[:20]}...] > '
     else:
         prompt = f'[{track_name}] > '
 
-    chosen = fzf.run_fzf(list(choices.keys()), prompt=prompt)[0]
+    chosen = fzf.run_fzf(list(TRACK_ACTIONS_CHOICES.keys()), prompt=prompt)[0]
     if chosen == '':
         return ('search',)
-    return choices[chosen], track
+    return TRACK_ACTIONS_CHOICES[chosen], track
 
 
 def play_track_in_playlist(state, track):

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,5 +1,4 @@
 import os
-import types
 
 import pytest
 
@@ -106,8 +105,8 @@ def test_update_data_paths_nests_everything_under_spotify_data():
 def test_launch_walks_screens_until_none(config, monkeypatch, no_fzf_check):
     """
     Pins the screen contract: every screen returns (next_screen_name, *args),
-    unpacked as `choice, *screen_args = fn(config, *screen_args)`. Any registry
-    replacing the getattr dispatch has to preserve this shape.
+    unpacked as `choice, *screen_args = fn(config, *screen_args)`, with the
+    name resolved through the registry.
     """
     seen = []
 
@@ -124,13 +123,13 @@ def test_launch_walks_screens_until_none(config, monkeypatch, no_fzf_check):
         return (None,)
 
     monkeypatch.setattr(
-        spotifz,
-        'screens',
-        types.SimpleNamespace(
-            home_screen=home_screen,
-            track_actions=track_actions,
-            play_track=play_track,
-        ),
+        spotifz.screens,
+        'SCREENS',
+        {
+            'home_screen': home_screen,
+            'track_actions': track_actions,
+            'play_track': play_track,
+        },
     )
 
     spotifz.launch(config)
@@ -147,9 +146,9 @@ def test_launch_stops_when_the_home_screen_returns_none(
 ):
     calls = []
     monkeypatch.setattr(
-        spotifz,
-        'screens',
-        types.SimpleNamespace(home_screen=lambda s: calls.append(s) or (None,)),
+        spotifz.screens,
+        'SCREENS',
+        {'home_screen': lambda s: calls.append(s) or (None,)},
     )
 
     spotifz.launch(config)
@@ -170,14 +169,58 @@ def test_launch_forwards_several_screen_args(config, monkeypatch, no_fzf_check):
         return (None,)
 
     monkeypatch.setattr(
-        spotifz,
-        'screens',
-        types.SimpleNamespace(home_screen=home_screen, device_actions=device_actions),
+        spotifz.screens,
+        'SCREENS',
+        {'home_screen': home_screen, 'device_actions': device_actions},
     )
 
     spotifz.launch(config)
 
     assert seen == [('device-1', 'extra')]
+
+
+def test_launch_resolves_the_entry_point_through_the_registry(
+    config, monkeypatch, no_fzf_check
+):
+    """
+    The first screen is looked up by name like every other hop, rather than
+    launch holding its own reference to screens.home_screen.
+    """
+    calls = []
+    monkeypatch.setattr(
+        spotifz.screens,
+        'SCREENS',
+        {'home_screen': lambda s: calls.append('registered') or (None,)},
+    )
+
+    spotifz.launch(config)
+
+    assert calls == ['registered']
+
+
+def test_launch_rejects_a_name_nothing_is_registered_under(
+    config, monkeypatch, no_fzf_check
+):
+    monkeypatch.setattr(
+        spotifz.screens, 'SCREENS', {'home_screen': lambda s: ('typo_screen',)}
+    )
+
+    with pytest.raises(spotifz.screens.UnknownScreen, match='typo_screen'):
+        spotifz.launch(config)
+
+
+@pytest.mark.parametrize('name', ['sp_devices', 'describe_playback', 'spotify'])
+def test_launch_rejects_a_module_name_that_is_not_a_screen(
+    name, config, monkeypatch, no_fzf_check
+):
+    """
+    The getattr dispatch this replaced reached every attribute of the screens
+    module -- helpers, constants and imports included.
+    """
+    monkeypatch.setitem(spotifz.screens.SCREENS, 'home_screen', lambda s: (name,))
+
+    with pytest.raises(spotifz.screens.UnknownScreen, match=name):
+        spotifz.launch(config)
 
 
 def test_launch_validates_before_checking_for_fzf(monkeypatch):
@@ -201,9 +244,9 @@ def test_launch_leaves_the_callers_config_alone(monkeypatch, no_fzf_check):
     cfg = valid_config()
     seen = []
     monkeypatch.setattr(
-        spotifz,
-        'screens',
-        types.SimpleNamespace(home_screen=lambda s: seen.append(s) or (None,)),
+        spotifz.screens,
+        'SCREENS',
+        {'home_screen': lambda s: seen.append(s) or (None,)},
     )
 
     spotifz.launch(cfg)

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 from spotipy import SpotifyException
 
@@ -106,6 +108,64 @@ def track_playback(name='Song', album='Album', artists=('A', 'B'), device='Lapto
             'artists': [{'name': artist} for artist in artists],
         },
     }
+
+
+# --- the registry ------------------------------------------------------------
+
+
+# Written out rather than derived, so adding a screen is a deliberate edit here
+# and never something that happens by accident.
+EXPECTED_SCREENS = {
+    'home_screen',
+    'search',
+    'current_playback',
+    'current_queue',
+    'list_devices',
+    'device_actions',
+    'resume',
+    'update_cache',
+    'track_actions',
+    'play_track',
+    'play_track_in_playlist',
+    'add_to_queue',
+}
+
+
+def test_the_registry_holds_exactly_the_screens():
+    assert set(screens.SCREENS) == EXPECTED_SCREENS
+
+
+def test_every_registered_screen_is_a_function_taking_the_state_first():
+    for name, fn in screens.SCREENS.items():
+        assert inspect.isfunction(fn), name
+        first = next(iter(inspect.signature(fn).parameters))
+        # An unused state parameter is spelled `_`, as in home_screen.
+        assert first in ('state', '_'), name
+
+
+def test_the_registry_keys_are_the_function_names():
+    """
+    What makes the strings the screens return safe to keep as the contract:
+    the key cannot drift from the definition it was taken from.
+    """
+    for name, fn in screens.SCREENS.items():
+        assert fn.__name__ == name
+
+
+@pytest.mark.parametrize('menu', [screens.HOME_CHOICES, screens.TRACK_ACTIONS_CHOICES])
+def test_every_menu_destination_is_a_registered_screen(menu):
+    for label, destination in menu.items():
+        assert destination in screens.SCREENS, label
+
+
+def test_a_helper_that_takes_the_state_is_not_a_screen():
+    """
+    sp_devices has a screen's signature and is called directly by list_devices.
+    The getattr dispatch could not tell the difference.
+    """
+    for helper in ('sp_devices', 'describe_playback', 'describe_queue'):
+        assert hasattr(screens, helper)
+        assert helper not in screens.SCREENS
 
 
 # --- describe_playback -------------------------------------------------------


### PR DESCRIPTION
`launch` did `getattr(screens, choice)` on a name returned by the previous screen, so any of the module's 35 attributes was a reachable destination — helpers, constants and imports included — and the set of screens was written down nowhere.

- [x] Hoist the menu choices to module constants
- [x] Register the screens explicitly (`@screen`)
- [x] Dispatch through the registry

**A decorator rather than a literal dict**, so a screen is named once, at its definition. The key is `fn.__name__`, so every name the screens already return survives unchanged — the strings stay the contract, and `test_screens.py` needed no edits to its ~30 assertions on them.

**The registry lives in `screens.py`, not a module of its own.** Registration is an import side effect; a separate module could be imported first and answer lookups from a legitimately empty dict.

**The entry point resolves through it too**, so `home_screen` is no longer spelled twice in two different mechanisms.

**`UnknownScreen` is deliberately not caught in `cli.main`.** A screen name is never user input and is never read from disk — `pending_screen` is session-only — so an unknown one is a bug in here, and the traceback naming it is the useful part. `LookupError` rather than `KeyError`, whose `__str__` reprs the message and would print it wrapped in quotes.

Menu labels moved to `HOME_CHOICES` / `TRACK_ACTIONS_CHOICES` so a test can check every destination against the registry. Misspelling one used to surface as an `AttributeError` after fzf had already exited.

**One rename:** `_redirect_to_devices`' parameter and `device_actions`' local, both called `screen`, are now `screen_name` — the new decorator shadowed them inside those two bodies, and neither ever held a screen.

Out of scope: renaming any screen; an enum in place of the name strings, which buys import-time typo detection over the test-time detection below for roughly ten times the diff; and item 3's deferred fixes, including `device_actions`' unguarded `transfer_playback` — in a file this touches, but a behaviour change.

**Testing:** 204 pass, 11 new — the 12 keys as a literal set, both menus' destinations, keys equal to function names, a helper with a screen's signature (`sp_devices`) rejected, and the loop raising on an unregistered name. Green on 3.9 and 3.13; `ruff check` and `ruff format --check` clean.
