### PR TITLE
Add a play history screen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,10 @@ quote-style = 'single'
 # sorting flake8 never had.
 select = ['E', 'F', 'I']
 
+[tool.ruff.lint.isort]
+# `builders` is tests/builders.py, which pytest puts on the path for the test
+# modules. Without this it sorts as a third-party package, next to pytest.
+known-first-party = ['builders']
+
 [tool.pytest.ini_options]
 testpaths = ['tests']

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Home Screen:
 4. [x] Play/Pause
 5. [x] Search My Library
 6. [x] Current Queue
+7. [x] Play History
 
 Selected Track:
 
@@ -20,11 +21,15 @@ Selected Track:
 2. [x] Play track
 3. [x] Add to Queue
 
-## TODO
+Selected Play:
 
-- current album in playlist
-- play history
-- current playback to lead to searching by artist, album etc as the input query to fzf
+1. [x] Play track
+2. [x] Add to Queue
+3. [x] Play in the playlist or album it was played in
+
+A play history row names the playlist a track was played from when that
+playlist is one of your own -- the name comes from the local cache, so one you
+have not run `Update Cache` for since adding goes unnamed.
 
 # Installation
 

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,11 @@ Selected Track:
 6. You should be able to call `spotifz` from your shell.
 7. Select `Update Cache` the first time you run `spotifz`.
 
+Upgrading a checkout that asks Spotify for a permission it did not ask for
+before invalidates the cached token, because the refresh token is tied to the
+set of scopes it was granted for. `spotifz` notices, says so, and re-runs the
+browser authorization once; nothing needs to be deleted by hand.
+
 `spotifz` writes two files of its own into `cache_path`, both named after the
 `user` in your config: `<user>_spotify.cache.json` holds the OAuth token, and
 `<user>_state.json` remembers the playback device you last chose, so you do not

--- a/readme.md
+++ b/readme.md
@@ -27,10 +27,6 @@ Selected Play:
 2. [x] Add to Queue
 3. [x] Play in the playlist or album it was played in
 
-A play history row names the playlist a track was played from when that
-playlist is one of your own -- the name comes from the local cache, so one you
-have not run `Update Cache` for since adding goes unnamed.
-
 # Installation
 
 1. Make sure you have set up a developer account with Spotify.
@@ -43,11 +39,6 @@ have not run `Update Cache` for since adding goes unnamed.
 5. Change to the root directory of this project and run `pip install .`
 6. You should be able to call `spotifz` from your shell.
 7. Select `Update Cache` the first time you run `spotifz`.
-
-Upgrading a checkout that asks Spotify for a permission it did not ask for
-before invalidates the cached token, because the refresh token is tied to the
-set of scopes it was granted for. `spotifz` notices, says so, and re-runs the
-browser authorization once; nothing needs to be deleted by hand.
 
 `spotifz` writes two files of its own into `cache_path`, both named after the
 `user` in your config: `<user>_spotify.cache.json` holds the OAuth token, and

--- a/spotifz/helpers/fzf.py
+++ b/spotifz/helpers/fzf.py
@@ -72,10 +72,6 @@ def run_fzf(search_items, prompt=None):
         text=True,
         stdout=subprocess.PIPE,
     )
-    # strip('\n'), not strip(): a candidate is returned exactly as it was
-    # given, and a bare strip would eat the padding off a row that lines up
-    # under a wider one -- which a caller matching the selection back against
-    # what it offered would then fail to recognise.
     selected = fuzzy_result.stdout.strip('\n').split('\n')
     return selected
 

--- a/spotifz/helpers/fzf.py
+++ b/spotifz/helpers/fzf.py
@@ -72,7 +72,11 @@ def run_fzf(search_items, prompt=None):
         text=True,
         stdout=subprocess.PIPE,
     )
-    selected = fuzzy_result.stdout.strip().split('\n')
+    # strip('\n'), not strip(): a candidate is returned exactly as it was
+    # given, and a bare strip would eat the padding off a row that lines up
+    # under a wider one -- which a caller matching the selection back against
+    # what it offered would then fail to recognise.
+    selected = fuzzy_result.stdout.strip('\n').split('\n')
     return selected
 
 

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -167,10 +167,11 @@ def _artist_names(item):
     return ', '.join(name for name in names if name)
 
 
-def describe_queue_item(item):
+def describe_item(item):
     """
-    One queued item, read in the same order as a search result: what it is,
-    what it came from, who made it.
+    One track or episode as a row, read in the same order as a search result:
+    what it is, what it came from, who made it. Shared by every screen that
+    lists items rather than describing one.
     """
     if item.get('type') == 'episode' or item.get('show') is not None:
         # Episodes carry show/publisher rather than album/artists.
@@ -211,7 +212,7 @@ def describe_queue(queue):
 
     marker_width = max(len(marker) for marker, _ in rows)
     return [
-        '{}  {}'.format(marker.rjust(marker_width), describe_queue_item(item))
+        '{}  {}'.format(marker.rjust(marker_width), describe_item(item))
         for marker, item in rows
     ]
 

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -174,6 +174,17 @@ def _one_line(value):
     return ' '.join(str(value if value is not None else '').split())
 
 
+def _track_prompt(track_name):
+    """
+    The prompt for a menu about one track. Long names are truncated so the
+    prompt does not push the choices off the line.
+    """
+    track_name = track_name.replace("'", '')
+    if len(track_name) > 20:
+        return f'[{track_name[:20]}...] > '
+    return f'[{track_name}] > '
+
+
 def _artist_names(item):
     names = (_one_line(artist.get('name')) for artist in item.get('artists') or [])
     return ', '.join(name for name in names if name)
@@ -247,6 +258,9 @@ class HistoryEntry(NamedTuple):
     track_id: str
     context_uri: Optional[str]
     context_type: Optional[str]
+    # What the context is called, where that is known without asking Spotify:
+    # a playlist of the user's own is named by the cache, an album by the track
+    # itself. Not the same thing as what the row shows -- see history_entries.
     context_name: Optional[str]
     played_at: str
 
@@ -285,21 +299,28 @@ def history_entries(response, playlist_names=None):
         if not track:
             continue
         context = item.get('context') or None
+        context_type = (context or {}).get('type')
         playlist_id = context_playlist_id(context)
-        # Only a playlist is named on the row: an album is already the row's
-        # second field, and an artist or Liked Songs adds nothing the row does
-        # not carry.
-        context_name = playlist_names.get(playlist_id) if playlist_id else None
+        if playlist_id:
+            context_name = playlist_names.get(playlist_id)
+        elif context_type == 'album':
+            context_name = _one_line((track.get('album') or {}).get('name')) or None
+        else:
+            context_name = None
 
+        # Only a playlist reaches the row. An album is already the row's second
+        # field, and an artist or Liked Songs adds nothing the row does not
+        # carry -- but both are still worth naming on the entry, for the action
+        # menu that offers to resume them.
         display = describe_item(track)
-        if context_name:
+        if playlist_id and context_name:
             display += spotify.DISPLAY_SEPARATOR + _one_line(context_name)
         entries.append(
             HistoryEntry(
                 display=display,
                 track_id=track.get('id'),
                 context_uri=(context or {}).get('uri'),
-                context_type=(context or {}).get('type'),
+                context_type=context_type,
                 context_name=context_name,
                 played_at=item.get('played_at') or '',
             )
@@ -528,20 +549,13 @@ def search(state):
 def context_action_label(entry):
     """
     The label for resuming what a track was played inside, or None when there
-    is nothing to resume. The name is whatever is already known -- the playlist
-    named off the cache when the rows were built, the album off the track --
-    and a playlist that was never cached still offers the action, just without
-    a name for it.
+    is nothing to resume. A playlist that was never cached has no name to offer
+    but is still worth offering, since the action needs only the uri.
     """
     if not entry.is_resumable:
         return None
-    name = entry.context_name
-    if not name and entry.context_type == 'album':
-        # The album is the row's second field, so it is on the display already.
-        parts = entry.display.split(spotify.DISPLAY_SEPARATOR)
-        name = parts[1] if len(parts) > 1 else None
-    if name:
-        return 'Play in {}'.format(name)
+    if entry.context_name:
+        return 'Play in {}'.format(entry.context_name)
     return 'Play in {}'.format(entry.context_type.capitalize())
 
 
@@ -560,17 +574,6 @@ def history_actions(_, entry):
     if chosen == '':
         return ('play_history',)
     return choices[chosen], entry, 'play_history'
-
-
-def _track_prompt(track_name):
-    """
-    The prompt for a menu about one track. Long names are truncated so the
-    prompt does not push the choices off the line.
-    """
-    track_name = track_name.replace("'", '')
-    if len(track_name) > 20:
-        return f'[{track_name[:20]}...] > '
-    return f'[{track_name}] > '
 
 
 @screen

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -1,4 +1,6 @@
 from collections import Counter
+from datetime import datetime, timezone
+from typing import NamedTuple, Optional
 
 from spotipy import SpotifyException
 
@@ -215,6 +217,156 @@ def describe_queue(queue):
         '{}  {}'.format(marker.rjust(marker_width), describe_item(item))
         for marker, item in rows
     ]
+
+
+# Contexts a track can be resumed *inside*. Spotify accepts the `offset` that
+# starts a context at a chosen track only for these two, so an artist or a
+# Liked Songs context would start somewhere the user did not pick.
+RESUMABLE_CONTEXTS = ('playlist', 'album')
+PLAYLIST_URI_PREFIX = 'spotify:playlist:'
+
+
+class HistoryEntry(NamedTuple):
+    """
+    One play out of the history. `track_id` and `name` are spelled the way
+    TrackRef spells them, which is what lets play_track and add_to_queue take
+    an entry without knowing which list it was picked from.
+    """
+
+    display: str
+    track_id: str
+    context_uri: Optional[str]
+    context_type: Optional[str]
+    context_name: Optional[str]
+    played_at: str
+
+    @property
+    def name(self):
+        # Cosmetic, for the fzf prompt only, as on TrackRef.
+        return self.display.split(spotify.DISPLAY_SEPARATOR)[0]
+
+    @property
+    def is_resumable(self):
+        return self.context_uri is not None and self.context_type in RESUMABLE_CONTEXTS
+
+
+def context_playlist_id(context):
+    """
+    The playlist id out of a context, or None for a context that is not a
+    playlist -- an album, an artist, Liked Songs, or no context at all, which
+    is what a track played from a radio or from search arrives with.
+    """
+    uri = (context or {}).get('uri') or ''
+    if not uri.startswith(PLAYLIST_URI_PREFIX):
+        return None
+    return uri[len(PLAYLIST_URI_PREFIX) :] or None
+
+
+def history_entries(response, playlist_names=None):
+    """
+    Maps the recently-played response onto entries. `playlist_names` is handed
+    in rather than read here, so this stays a pure function of the response and
+    the caller owns the one cache read.
+    """
+    playlist_names = playlist_names or {}
+    entries = []
+    for item in (response or {}).get('items') or []:
+        track = (item or {}).get('track')
+        if not track:
+            continue
+        context = item.get('context') or None
+        playlist_id = context_playlist_id(context)
+        # Only a playlist is named on the row: an album is already the row's
+        # second field, and an artist or Liked Songs adds nothing the row does
+        # not carry.
+        context_name = playlist_names.get(playlist_id) if playlist_id else None
+
+        display = describe_item(track)
+        if context_name:
+            display += spotify.DISPLAY_SEPARATOR + _one_line(context_name)
+        entries.append(
+            HistoryEntry(
+                display=display,
+                track_id=track.get('id'),
+                context_uri=(context or {}).get('uri'),
+                context_type=(context or {}).get('type'),
+                context_name=context_name,
+                played_at=item.get('played_at') or '',
+            )
+        )
+    return entries
+
+
+def history_playlist_ids(response):
+    """The playlist ids a response refers to, for the caller's cache read."""
+    ids = (
+        context_playlist_id((item or {}).get('context'))
+        for item in (response or {}).get('items') or []
+    )
+    return [playlist_id for playlist_id in ids if playlist_id]
+
+
+# Spotify sends `2026-08-29T21:14:03.123Z`. datetime.fromisoformat only accepts
+# that trailing Z from 3.11, and this package supports 3.9, so the fixed prefix
+# is parsed instead -- which is indifferent to the Z and to how many fractional
+# digits came with it.
+PLAYED_AT_FORMAT = '%Y-%m-%dT%H:%M:%S'
+PLAYED_AT_LENGTH = 19
+
+
+def _parse_played_at(played_at):
+    try:
+        parsed = datetime.strptime(played_at[:PLAYED_AT_LENGTH], PLAYED_AT_FORMAT)
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def played_ago(played_at, now):
+    """
+    How long ago, compactly. Empty for a timestamp that will not parse, so a
+    row that Spotify described oddly loses its suffix rather than the screen.
+    """
+    parsed = _parse_played_at(played_at)
+    if parsed is None:
+        return ''
+
+    seconds = (now - parsed).total_seconds()
+    if seconds < 0:
+        # Clock skew between here and Spotify. 'in 3 minutes' would be absurd
+        # on a history, so the newest row just reads as the newest.
+        return 'just now'
+    minutes, hours, days = seconds // 60, seconds // 3600, seconds // 86400
+    if minutes < 1:
+        return 'just now'
+    if hours < 1:
+        return '{:.0f}m ago'.format(minutes)
+    if days < 1:
+        return '{:.0f}h ago'.format(hours)
+    if days < 2:
+        return 'yesterday'
+    return '{:.0f}d ago'.format(days)
+
+
+def describe_history(entries, now):
+    """
+    Builds the display rows for the play history, newest first as Spotify
+    returns it. Numbered the way the queue is: the number is a position on
+    screen, and it is also what keeps two plays of the same track from
+    rendering as the same row.
+    """
+    if not entries:
+        return []
+
+    marker_width = len(str(len(entries)))
+    rows = []
+    for position, entry in enumerate(entries, 1):
+        row = '{}  {}'.format(str(position).rjust(marker_width), entry.display)
+        ago = played_ago(entry.played_at, now)
+        if ago:
+            row += '  ({})'.format(ago)
+        rows.append(row)
+    return rows
 
 
 @screen

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -88,10 +88,20 @@ HOME_CHOICES = {
     '[ 4 ] Play/Pause': 'resume',
     '[ 5 ] Update Cache': 'update_cache',
     '[ 6 ] Current Queue': 'current_queue',
+    '[ 7 ] Play History': 'play_history',
 }
 
 TRACK_ACTIONS_CHOICES = {
     'Play Track in Playlist': 'play_track_in_context',
+    'Play Track': 'play_track',
+    'Add to Queue': 'add_to_queue',
+}
+
+# What a track picked out of the play history can do without knowing anything
+# about where it was played. Resuming the context it came from is offered on
+# top of these, and only when there is one worth resuming, so it cannot be a
+# fixed entry here.
+HISTORY_ACTIONS_CHOICES = {
     'Play Track': 'play_track',
     'Add to Queue': 'add_to_queue',
 }
@@ -348,6 +358,15 @@ def played_ago(played_at, now):
     return '{:.0f}d ago'.format(days)
 
 
+def current_time():
+    """
+    Exists to be replaceable. The relative times on the history rows are read
+    against this, and a test that cannot hold it still would be asserting
+    against the wall clock.
+    """
+    return datetime.now(timezone.utc)
+
+
 def describe_history(entries, now):
     """
     Builds the display rows for the play history, newest first as Spotify
@@ -398,6 +417,32 @@ def current_queue(state):
 
     fzf.run_fzf(rows, prompt='[Queue] > ')
     return ('home_screen',)
+
+
+@screen
+def play_history(state):
+    """
+    What Spotify recorded as recently played -- tracks only, newest first, one
+    row per play rather than per track, since playing something three times is
+    the interesting part of a history.
+    """
+    sp = spotify.get_spotify_client(state.config)
+    response = sp.current_user_recently_played()
+    playlist_names = spotify.read_playlist_names(
+        state.config, history_playlist_ids(response)
+    )
+    entries = history_entries(response, playlist_names)
+    rows = describe_history(entries, current_time())
+    if not rows:
+        return ('home_screen',)
+
+    chosen = fzf.run_fzf(rows, prompt='[History] > ')[0]
+    # Row -> entry, the way list_devices maps a label back to a device. The
+    # position each row is numbered with is what makes the keys unique.
+    entry = dict(zip(rows, entries)).get(chosen)
+    if entry is None:
+        return ('home_screen',)
+    return 'history_actions', entry
 
 
 @screen
@@ -480,6 +525,54 @@ def search(state):
     return 'track_actions', spotify.parse_track_line(chosen), 'search'
 
 
+def context_action_label(entry):
+    """
+    The label for resuming what a track was played inside, or None when there
+    is nothing to resume. The name is whatever is already known -- the playlist
+    named off the cache when the rows were built, the album off the track --
+    and a playlist that was never cached still offers the action, just without
+    a name for it.
+    """
+    if not entry.is_resumable:
+        return None
+    name = entry.context_name
+    if not name and entry.context_type == 'album':
+        # The album is the row's second field, so it is on the display already.
+        parts = entry.display.split(spotify.DISPLAY_SEPARATOR)
+        name = parts[1] if len(parts) > 1 else None
+    if name:
+        return 'Play in {}'.format(name)
+    return 'Play in {}'.format(entry.context_type.capitalize())
+
+
+@screen
+def history_actions(_, entry):
+    """
+    Everything here is already on the entry, so opening this menu costs no
+    request -- which is what naming the context when the rows were built buys.
+    """
+    choices = dict(HISTORY_ACTIONS_CHOICES)
+    context_label = context_action_label(entry)
+    if context_label is not None:
+        choices[context_label] = 'play_track_in_context'
+
+    chosen = fzf.run_fzf(list(choices.keys()), prompt=_track_prompt(entry.name))[0]
+    if chosen == '':
+        return ('play_history',)
+    return choices[chosen], entry, 'play_history'
+
+
+def _track_prompt(track_name):
+    """
+    The prompt for a menu about one track. Long names are truncated so the
+    prompt does not push the choices off the line.
+    """
+    track_name = track_name.replace("'", '')
+    if len(track_name) > 20:
+        return f'[{track_name[:20]}...] > '
+    return f'[{track_name}] > '
+
+
 @screen
 def track_actions(_, track, origin):
     """
@@ -488,13 +581,9 @@ def track_actions(_, track, origin):
     out at each call site rather than defaulted, so a new caller has to say
     where it came from instead of silently inheriting the search.
     """
-    track_name = track.name.replace("'", '')
-    if len(track_name) > 20:
-        prompt = f'[{track_name[:20]}...] > '
-    else:
-        prompt = f'[{track_name}] > '
-
-    chosen = fzf.run_fzf(list(TRACK_ACTIONS_CHOICES.keys()), prompt=prompt)[0]
+    chosen = fzf.run_fzf(
+        list(TRACK_ACTIONS_CHOICES.keys()), prompt=_track_prompt(track.name)
+    )[0]
     if chosen == '':
         return (origin,)
     return TRACK_ACTIONS_CHOICES[chosen], track, origin

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -1,6 +1,5 @@
 from collections import Counter
 from datetime import datetime, timezone
-from typing import NamedTuple, Optional
 
 from spotipy import SpotifyException
 
@@ -240,103 +239,6 @@ def describe_queue(queue):
     ]
 
 
-# Contexts a track can be resumed *inside*. Spotify accepts the `offset` that
-# starts a context at a chosen track only for these two, so an artist or a
-# Liked Songs context would start somewhere the user did not pick.
-RESUMABLE_CONTEXTS = ('playlist', 'album')
-PLAYLIST_URI_PREFIX = 'spotify:playlist:'
-
-
-class HistoryEntry(NamedTuple):
-    """
-    One play out of the history. `track_id` and `name` are spelled the way
-    TrackRef spells them, which is what lets play_track and add_to_queue take
-    an entry without knowing which list it was picked from.
-    """
-
-    display: str
-    track_id: str
-    context_uri: Optional[str]
-    context_type: Optional[str]
-    # What the context is called, where that is known without asking Spotify:
-    # a playlist of the user's own is named by the cache, an album by the track
-    # itself. Not the same thing as what the row shows -- see history_entries.
-    context_name: Optional[str]
-    played_at: str
-
-    @property
-    def name(self):
-        # Cosmetic, for the fzf prompt only, as on TrackRef.
-        return self.display.split(spotify.DISPLAY_SEPARATOR)[0]
-
-    @property
-    def is_resumable(self):
-        return self.context_uri is not None and self.context_type in RESUMABLE_CONTEXTS
-
-
-def context_playlist_id(context):
-    """
-    The playlist id out of a context, or None for a context that is not a
-    playlist -- an album, an artist, Liked Songs, or no context at all, which
-    is what a track played from a radio or from search arrives with.
-    """
-    uri = (context or {}).get('uri') or ''
-    if not uri.startswith(PLAYLIST_URI_PREFIX):
-        return None
-    return uri[len(PLAYLIST_URI_PREFIX) :] or None
-
-
-def history_entries(response, playlist_names=None):
-    """
-    Maps the recently-played response onto entries. `playlist_names` is handed
-    in rather than read here, so this stays a pure function of the response and
-    the caller owns the one cache read.
-    """
-    playlist_names = playlist_names or {}
-    entries = []
-    for item in (response or {}).get('items') or []:
-        track = (item or {}).get('track')
-        if not track:
-            continue
-        context = item.get('context') or None
-        context_type = (context or {}).get('type')
-        playlist_id = context_playlist_id(context)
-        if playlist_id:
-            context_name = playlist_names.get(playlist_id)
-        elif context_type == 'album':
-            context_name = _one_line((track.get('album') or {}).get('name')) or None
-        else:
-            context_name = None
-
-        # Only a playlist reaches the row. An album is already the row's second
-        # field, and an artist or Liked Songs adds nothing the row does not
-        # carry -- but both are still worth naming on the entry, for the action
-        # menu that offers to resume them.
-        display = describe_item(track)
-        if playlist_id and context_name:
-            display += spotify.DISPLAY_SEPARATOR + _one_line(context_name)
-        entries.append(
-            HistoryEntry(
-                display=display,
-                track_id=track.get('id'),
-                context_uri=(context or {}).get('uri'),
-                context_type=context_type,
-                context_name=context_name,
-                played_at=item.get('played_at') or '',
-            )
-        )
-    return entries
-
-
-def history_playlist_ids(response):
-    """The playlist ids a response refers to, for the caller's cache read."""
-    ids = (
-        context_playlist_id((item or {}).get('context'))
-        for item in (response or {}).get('items') or []
-    )
-    return [playlist_id for playlist_id in ids if playlist_id]
-
-
 # Spotify sends `2026-08-29T21:14:03.123Z`. datetime.fromisoformat only accepts
 # that trailing Z from 3.11, and this package supports 3.9, so the fixed prefix
 # is parsed instead -- which is indifferent to the Z and to how many fractional
@@ -388,6 +290,19 @@ def current_time():
     return datetime.now(timezone.utc)
 
 
+def describe_history_item(entry):
+    """
+    One play as a row. Only a playlist is named: an album is already the row's
+    second field, and an artist or Liked Songs adds nothing the row does not
+    carry -- though both are still named on the entry, for the action menu that
+    offers to resume them.
+    """
+    row = describe_item(entry.track)
+    if entry.context_type == 'playlist' and entry.context_name:
+        row += spotify.DISPLAY_SEPARATOR + _one_line(entry.context_name)
+    return row
+
+
 def describe_history(entries, now):
     """
     Builds the display rows for the play history, newest first as Spotify
@@ -401,7 +316,9 @@ def describe_history(entries, now):
     marker_width = len(str(len(entries)))
     rows = []
     for position, entry in enumerate(entries, 1):
-        row = '{}  {}'.format(str(position).rjust(marker_width), entry.display)
+        row = '{}  {}'.format(
+            str(position).rjust(marker_width), describe_history_item(entry)
+        )
         ago = played_ago(entry.played_at, now)
         if ago:
             row += '  ({})'.format(ago)
@@ -450,9 +367,9 @@ def play_history(state):
     sp = spotify.get_spotify_client(state.config)
     response = sp.current_user_recently_played()
     playlist_names = spotify.read_playlist_names(
-        state.config, history_playlist_ids(response)
+        state.config, spotify.history_playlist_ids(response)
     )
-    entries = history_entries(response, playlist_names)
+    entries = spotify.history_entries(response, playlist_names)
     rows = describe_history(entries, current_time())
     if not rows:
         return ('home_screen',)
@@ -555,7 +472,7 @@ def context_action_label(entry):
     if not entry.is_resumable:
         return None
     if entry.context_name:
-        return 'Play in {}'.format(entry.context_name)
+        return 'Play in {}'.format(_one_line(entry.context_name))
     return 'Play in {}'.format(entry.context_type.capitalize())
 
 

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -324,11 +324,17 @@ def search(state):
     # An empty selection -- the user hit Esc -- carries no separator.
     if spotify.SEPARATOR not in chosen:
         return ('home_screen',)
-    return 'track_actions', spotify.parse_track_line(chosen)
+    return 'track_actions', spotify.parse_track_line(chosen), 'search'
 
 
 @screen
-def track_actions(_, track):
+def track_actions(_, track, origin):
+    """
+    `origin` is the screen the track was picked on, carried through every
+    action below so each of them returns where the user actually was. Spelled
+    out at each call site rather than defaulted, so a new caller has to say
+    where it came from instead of silently inheriting the search.
+    """
     track_name = track.name.replace("'", '')
     if len(track_name) > 20:
         prompt = f'[{track_name[:20]}...] > '
@@ -337,12 +343,12 @@ def track_actions(_, track):
 
     chosen = fzf.run_fzf(list(TRACK_ACTIONS_CHOICES.keys()), prompt=prompt)[0]
     if chosen == '':
-        return ('search',)
-    return TRACK_ACTIONS_CHOICES[chosen], track
+        return (origin,)
+    return TRACK_ACTIONS_CHOICES[chosen], track, origin
 
 
 @screen
-def play_track_in_context(state, track):
+def play_track_in_context(state, track, origin):
     """
     Plays the track inside whatever it was found in, so what follows it is the
     rest of that playlist or album rather than nothing. `offset` is what starts
@@ -360,12 +366,12 @@ def play_track_in_context(state, track):
         offset={'uri': f'spotify:track:{track.track_id}'},
     )
     if not started:
-        return _redirect_to_devices(state, 'play_track_in_context', track)
-    return ('search',)
+        return _redirect_to_devices(state, 'play_track_in_context', track, origin)
+    return (origin,)
 
 
 @screen
-def play_track(state, track):
+def play_track(state, track, origin):
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
     started = device_id is not None and _player_command(
@@ -375,15 +381,15 @@ def play_track(state, track):
         uris=[f'spotify:track:{track.track_id}'],
     )
     if not started:
-        return _redirect_to_devices(state, 'play_track', track)
-    return ('search',)
+        return _redirect_to_devices(state, 'play_track', track, origin)
+    return (origin,)
 
 
 @screen
-def add_to_queue(state, track):
+def add_to_queue(state, track, origin):
     """
     Appends to the queue, so tracks can be stacked one after another without
-    leaving the results -- which is why this returns to the search.
+    leaving the list they were picked from -- which is why this returns there.
     """
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
@@ -394,5 +400,5 @@ def add_to_queue(state, track):
         device_id=device_id,
     )
     if not queued:
-        return _redirect_to_devices(state, 'add_to_queue', track)
-    return ('search',)
+        return _redirect_to_devices(state, 'add_to_queue', track, origin)
+    return (origin,)

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -89,7 +89,7 @@ HOME_CHOICES = {
 }
 
 TRACK_ACTIONS_CHOICES = {
-    'Play Track in Playlist': 'play_track_in_playlist',
+    'Play Track in Playlist': 'play_track_in_context',
     'Play Track': 'play_track',
     'Add to Queue': 'add_to_queue',
 }
@@ -342,18 +342,25 @@ def track_actions(_, track):
 
 
 @screen
-def play_track_in_playlist(state, track):
+def play_track_in_context(state, track):
+    """
+    Plays the track inside whatever it was found in, so what follows it is the
+    rest of that playlist or album rather than nothing. `offset` is what starts
+    the context at this track, and Spotify accepts it only for a playlist or an
+    album -- which is why callers that hold some other kind of context do not
+    route here.
+    """
     sp = spotify.get_spotify_client(state.config)
     device_id = _resolve_device(state, sp.current_playback())
     started = device_id is not None and _player_command(
         state,
         sp.start_playback,
         device_id=device_id,
-        context_uri=f'spotify:playlist:{track.playlist_id}',
+        context_uri=track.context_uri,
         offset={'uri': f'spotify:track:{track.track_id}'},
     )
     if not started:
-        return _redirect_to_devices(state, 'play_track_in_playlist', track)
+        return _redirect_to_devices(state, 'play_track_in_context', track)
     return ('search',)
 
 

--- a/spotifz/spotify/__init__.py
+++ b/spotifz/spotify/__init__.py
@@ -12,4 +12,4 @@ from .sink import (  # noqa: F401
     parse_track_line,
     sink_all_tracks,
 )
-from .storage import update_cache  # noqa: F401
+from .storage import read_playlist_names, update_cache  # noqa: F401

--- a/spotifz/spotify/__init__.py
+++ b/spotifz/spotify/__init__.py
@@ -1,4 +1,11 @@
 from .client import get_spotify_client  # noqa: F401
+from .history import (  # noqa: F401
+    RESUMABLE_CONTEXTS,
+    HistoryEntry,
+    context_playlist_id,
+    history_entries,
+    history_playlist_ids,
+)
 from .sink import (  # noqa: F401
     ADDED_AT_FIELD,
     DISPLAY_FIELD,

--- a/spotifz/spotify/auth.py
+++ b/spotifz/spotify/auth.py
@@ -10,6 +10,7 @@ scope = ' '.join(
         'user-modify-playback-state',
         'user-read-currently-playing',
         'user-read-playback-state',
+        'user-read-recently-played',
     ]
 )
 

--- a/spotifz/spotify/history.py
+++ b/spotifz/spotify/history.py
@@ -1,0 +1,95 @@
+from typing import Any, Dict, NamedTuple, Optional
+
+# Contexts a track can be resumed *inside*. Spotify accepts the `offset` that
+# starts a context at a chosen track only for these two, so an artist or a
+# Liked Songs context would start somewhere the user did not pick.
+RESUMABLE_CONTEXTS = ('playlist', 'album')
+PLAYLIST_URI_PREFIX = 'spotify:playlist:'
+
+
+class HistoryEntry(NamedTuple):
+    """
+    One play out of `me/player/recently-played`. `track_id` and `name` are
+    spelled the way TrackRef spells them, which is what lets play_track and
+    add_to_queue take an entry without knowing which list it was picked from.
+
+    It holds the track it was given rather than a rendered row: what a play
+    looks like on screen belongs to whatever is doing the rendering, and a
+    record that stored the row would only have to be taken apart again to
+    recover the fields it was built from.
+    """
+
+    track: Dict[str, Any]
+    track_id: Optional[str]
+    context_uri: Optional[str]
+    context_type: Optional[str]
+    # What the context is called, where that is known without asking Spotify:
+    # a playlist of the user's own is named by the cache, an album by the track
+    # itself. An artist or Liked Songs context goes unnamed.
+    context_name: Optional[str]
+    played_at: str
+
+    @property
+    def name(self):
+        return self.track.get('name') or ''
+
+    @property
+    def is_resumable(self):
+        return self.context_uri is not None and self.context_type in RESUMABLE_CONTEXTS
+
+
+def context_playlist_id(context):
+    """
+    The playlist id out of a context, or None for a context that is not a
+    playlist -- an album, an artist, Liked Songs, or no context at all, which
+    is what a track played from a radio or from search arrives with.
+    """
+    uri = (context or {}).get('uri') or ''
+    if not uri.startswith(PLAYLIST_URI_PREFIX):
+        return None
+    return uri[len(PLAYLIST_URI_PREFIX) :] or None
+
+
+def history_playlist_ids(response):
+    """The playlist ids a response refers to, for the caller's cache read."""
+    ids = (
+        context_playlist_id((item or {}).get('context'))
+        for item in (response or {}).get('items') or []
+    )
+    return [playlist_id for playlist_id in ids if playlist_id]
+
+
+def history_entries(response, playlist_names=None):
+    """
+    Maps the recently-played response onto entries. `playlist_names` is handed
+    in rather than read here -- storage.read_playlist_names is what produces it
+    -- so this stays a pure function of the response, and the one cache read is
+    the caller's.
+    """
+    playlist_names = playlist_names or {}
+    entries = []
+    for item in (response or {}).get('items') or []:
+        track = (item or {}).get('track')
+        if not track:
+            continue
+        context = item.get('context') or None
+        context_type = (context or {}).get('type')
+        playlist_id = context_playlist_id(context)
+        if playlist_id:
+            context_name = playlist_names.get(playlist_id)
+        elif context_type == 'album':
+            context_name = (track.get('album') or {}).get('name')
+        else:
+            context_name = None
+
+        entries.append(
+            HistoryEntry(
+                track=track,
+                track_id=track.get('id'),
+                context_uri=(context or {}).get('uri'),
+                context_type=context_type,
+                context_name=context_name or None,
+                played_at=item.get('played_at') or '',
+            )
+        )
+    return entries

--- a/spotifz/spotify/sink.py
+++ b/spotifz/spotify/sink.py
@@ -39,6 +39,13 @@ class TrackRef(NamedTuple):
         # DISPLAY_SEPARATOR truncates the prompt and nothing else.
         return self.display.split(DISPLAY_SEPARATOR)[0]
 
+    @property
+    def context_uri(self):
+        # What to play this track *within*. A track reached through the search
+        # was found inside a playlist, so that is its context; other sources of
+        # a track carry a context of their own and name it the same way.
+        return 'spotify:playlist:{}'.format(self.playlist_id)
+
 
 def _clean(value):
     """

--- a/spotifz/spotify/storage.py
+++ b/spotifz/spotify/storage.py
@@ -92,6 +92,37 @@ def cache_data(spotify_client, config):
             json.dump(playlist, ofile)
 
 
+def read_playlist_names(config, playlist_ids):
+    """
+    Maps playlist id -> name out of the cache, for the ids asked for. A
+    playlist that is not cached -- someone else's, or one added since the last
+    update -- is simply absent from the result rather than an error: a name is
+    decoration on a row, and a stale cache must not be able to break a screen.
+
+    Opens only the files named, rather than reading the whole library the way
+    sink_all_tracks does, because a caller here holds a handful of ids.
+    """
+    playlist_dir = config['data_paths']['playlist_path']
+    names = {}
+    for playlist_id in set(playlist_ids):
+        # An id is a path segment here, and it reached us out of a uri in an
+        # API response rather than from this cache. A base62 Spotify id can
+        # hold neither, so anything that could climb out of the directory is
+        # not an id we have a file for anyway.
+        if not playlist_id or os.path.basename(playlist_id) != playlist_id:
+            continue
+        try:
+            with open(os.path.join(playlist_dir, playlist_id)) as ifi:
+                playlist = json.load(ifi)
+        except (OSError, ValueError):
+            # Missing, unreadable, or half-written by an interrupted update.
+            continue
+        name = playlist.get('name') if isinstance(playlist, dict) else None
+        if name:
+            names[playlist_id] = name
+    return names
+
+
 KEEP_BACKUPS = 3
 
 

--- a/tests/builders.py
+++ b/tests/builders.py
@@ -1,0 +1,30 @@
+"""
+Builders for Spotify responses that more than one test module needs. Anything
+used by a single module stays a local helper in it, as most of these are.
+"""
+
+
+def history_item(
+    name='Song',
+    track_id='track-1',
+    album='Album',
+    artists=('A', 'B'),
+    context=None,
+    played_at='2026-08-30T10:00:00.123Z',
+):
+    """One entry as `me/player/recently-played` returns it."""
+    return {
+        'track': {
+            'type': 'track',
+            'id': track_id,
+            'name': name,
+            'album': {'name': album},
+            'artists': [{'name': artist} for artist in artists],
+        },
+        'context': context,
+        'played_at': played_at,
+    }
+
+
+def playlist_context(playlist_id='pl-1'):
+    return {'type': 'playlist', 'uri': 'spotify:playlist:{}'.format(playlist_id)}

--- a/tests/test_fzf.py
+++ b/tests/test_fzf.py
@@ -198,6 +198,35 @@ def test_run_fzf_passes_candidates_on_stdin(fake_fzf):
     assert selected == ['chosen line']
 
 
+def test_run_fzf_returns_a_row_exactly_as_it_offered_it(monkeypatch):
+    """
+    A caller that numbers its rows pads the narrow ones so they line up, and
+    then matches the selection back against what it showed. fzf returns the
+    line untouched, so anything trimmed here is a row its own caller can no
+    longer recognise.
+    """
+    row = ' 1  Song A :: Album :: Artist  (2h ago)'
+
+    def _run(cmd, **kwargs):
+        # What fzf actually writes: the chosen line and a newline.
+        return subprocess.CompletedProcess(cmd, 0, stdout=row + '\n')
+
+    monkeypatch.setattr(fzf.subprocess, 'run', _run)
+
+    assert run_fzf([row, '10  Song J :: Album :: Artist  (3d ago)']) == [row]
+
+
+def test_run_fzf_reads_an_abandoned_search_as_an_empty_selection(monkeypatch):
+    """Esc: fzf writes nothing, and every caller tests for ''."""
+
+    def _run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 130, stdout='')
+
+    monkeypatch.setattr(fzf.subprocess, 'run', _run)
+
+    assert run_fzf(['a', 'b']) == ['']
+
+
 def test_run_fzf_defaults_the_prompt(fake_fzf):
     run_fzf(['a'])
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,134 @@
+import pytest
+
+from builders import history_item, playlist_context
+from spotifz.spotify import history
+
+
+def test_context_playlist_id_reads_a_playlist():
+    assert history.context_playlist_id(playlist_context('pl-1')) == 'pl-1'
+
+
+@pytest.mark.parametrize(
+    'context',
+    [
+        None,
+        {},
+        {'type': 'album', 'uri': 'spotify:album:al-1'},
+        {'type': 'artist', 'uri': 'spotify:artist:ar-1'},
+        {'type': 'collection', 'uri': 'spotify:user:tester:collection'},
+        {'type': 'playlist', 'uri': 'spotify:playlist:'},
+        {'type': 'playlist'},
+    ],
+)
+def test_context_playlist_id_reads_nothing_else(context):
+    assert history.context_playlist_id(context) is None
+
+
+def test_history_entries_says_nothing_without_a_response():
+    """No history at all comes back as a 204, which spotipy returns as None."""
+    assert history.history_entries(None) == []
+    assert history.history_entries({}) == []
+    assert history.history_entries({'items': None}) == []
+
+
+def test_history_entries_reads_a_track():
+    entry = history.history_entries({'items': [history_item()]})[0]
+
+    assert entry.name == 'Song'
+    assert entry.track['album']['name'] == 'Album'
+    assert entry.track_id == 'track-1'
+    assert entry.played_at == '2026-08-30T10:00:00.123Z'
+    assert entry.context_uri is None
+    assert entry.context_name is None
+
+
+def test_history_entries_names_a_cached_playlist():
+    response = {'items': [history_item(context=playlist_context('pl-1'))]}
+
+    entry = history.history_entries(response, {'pl-1': 'Road Trip'})[0]
+
+    assert entry.context_name == 'Road Trip'
+    assert entry.context_uri == 'spotify:playlist:pl-1'
+    assert entry.context_type == 'playlist'
+
+
+def test_history_entries_leaves_an_uncached_playlist_unnamed():
+    """
+    Someone else's playlist, or one added since the last Update Cache. The row
+    keeps everything the API gave it and just gains no fourth field.
+    """
+    response = {'items': [history_item(context=playlist_context('pl-9'))]}
+
+    entry = history.history_entries(response, {'pl-1': 'Road Trip'})[0]
+
+    assert entry.context_name is None
+    # Still resumable: the action does not need the name, only the uri.
+    assert entry.context_uri == 'spotify:playlist:pl-9'
+    assert entry.is_resumable
+
+
+def test_history_entries_names_an_album_context_off_the_track():
+    """
+    No lookup needed: an album context is the album the track already names.
+    """
+    context = {'type': 'album', 'uri': 'spotify:album:al-1'}
+    response = {'items': [history_item(album='Mezzanine', context=context)]}
+
+    entry = history.history_entries(response)[0]
+
+    assert entry.context_name == 'Mezzanine'
+    assert entry.is_resumable
+
+
+def test_history_entries_skips_an_entry_without_a_track():
+    response = {'items': [history_item(), None, {'track': None}, history_item('Other')]}
+
+    assert [entry.name for entry in history.history_entries(response)] == [
+        'Song',
+        'Other',
+    ]
+
+
+def test_an_entry_is_only_resumable_in_a_playlist_or_an_album():
+    """
+    Spotify accepts the offset that starts a context at the chosen track only
+    for those two; anywhere else it would start somewhere the user did not pick.
+    """
+    resumable = {
+        'playlist': 'spotify:playlist:pl-1',
+        'album': 'spotify:album:al-1',
+    }
+    for context_type, uri in resumable.items():
+        context = {'type': context_type, 'uri': uri}
+        assert history.history_entries({'items': [history_item(context=context)]})[
+            0
+        ].is_resumable, context_type
+
+    not_resumable = {
+        'artist': 'spotify:artist:ar-1',
+        'collection': 'spotify:user:tester:collection',
+    }
+    for context_type, uri in not_resumable.items():
+        context = {'type': context_type, 'uri': uri}
+        assert not history.history_entries({'items': [history_item(context=context)]})[
+            0
+        ].is_resumable, context_type
+
+    assert not history.history_entries({'items': [history_item()]})[0].is_resumable
+
+
+def test_history_playlist_ids_lists_what_the_caller_has_to_look_up():
+    response = {
+        'items': [
+            history_item(context=playlist_context('pl-1')),
+            history_item(context={'type': 'album', 'uri': 'spotify:album:al-1'}),
+            history_item(context=None),
+            history_item(context=playlist_context('pl-2')),
+        ]
+    }
+
+    assert history.history_playlist_ids(response) == ['pl-1', 'pl-2']
+
+
+def test_history_playlist_ids_says_nothing_without_a_response():
+    assert history.history_playlist_ids(None) == []

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -514,14 +514,19 @@ def test_history_entries_leaves_an_uncached_playlist_unnamed():
     assert entry.is_resumable
 
 
-def test_history_entries_does_not_name_an_album_context():
-    """The album is already the row's second field."""
+def test_history_entries_keeps_an_album_context_off_the_row():
+    """
+    The album is already the row's second field, so repeating it would be
+    noise -- but the entry still knows the name, for the action that offers to
+    resume it.
+    """
     context = {'type': 'album', 'uri': 'spotify:album:al-1'}
-    response = {'items': [history_item(context=context)]}
+    response = {'items': [history_item(album='Mezzanine', context=context)]}
 
     entry = screens.history_entries(response)[0]
 
-    assert entry.display == 'Song :: Album :: A, B'
+    assert entry.display == 'Song :: Mezzanine :: A, B'
+    assert entry.context_name == 'Mezzanine'
     assert entry.is_resumable
 
 

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -158,6 +158,16 @@ def test_every_menu_destination_is_a_registered_screen(menu):
         assert destination in screens.SCREENS, label
 
 
+def test_every_track_action_accepts_the_screen_it_was_entered_from():
+    """
+    An action that dropped `origin` would compile and then strand the user on
+    whichever screen its own return value happened to name.
+    """
+    for label, destination in screens.TRACK_ACTIONS_CHOICES.items():
+        params = list(inspect.signature(screens.SCREENS[destination]).parameters)
+        assert params[-1] == 'origin', label
+
+
 def test_a_helper_that_takes_the_state_is_not_a_screen():
     """
     sp_devices has a screen's signature and is called directly by list_devices.
@@ -606,9 +616,10 @@ def test_search_parses_the_selected_line_into_a_track_ref(state, fzf_sink):
         )
     )
 
-    choice, track = screens.search(state)
+    choice, track, origin = screens.search(state)
 
     assert choice == 'track_actions'
+    assert origin == 'search'
     assert track.track_id == 'track-1'
     assert track.playlist_id == 'pl-1'
     assert track.display == 'Song :: Album :: A, B :: Road Trip'
@@ -626,19 +637,41 @@ def test_track_actions_forwards_the_track_props(state, fzf):
     fzf('Play Track')
     track = track_ref('Song :: Album :: A :: Road Trip')
 
-    assert screens.track_actions(state, track) == ('play_track', track)
+    assert screens.track_actions(state, track, 'search') == (
+        'play_track',
+        track,
+        'search',
+    )
 
 
-def test_track_actions_returns_to_search_on_an_empty_selection(state, fzf):
-    fzf('')
+def test_track_actions_returns_to_where_the_track_was_picked(state, fzf):
+    """
+    Esc goes back to the list the user was reading, whichever one that was --
+    the search here, the play history for a track picked there.
+    """
+    fzf('', '')
 
-    assert screens.track_actions(state, track_ref('Song')) == ('search',)
+    assert screens.track_actions(state, track_ref('Song'), 'search') == ('search',)
+    assert screens.track_actions(state, track_ref('Song'), 'play_history') == (
+        'play_history',
+    )
+
+
+def test_track_actions_carries_the_origin_to_the_action(state, fzf):
+    fzf('Add to Queue')
+    track = track_ref('Song')
+
+    assert screens.track_actions(state, track, 'play_history') == (
+        'add_to_queue',
+        track,
+        'play_history',
+    )
 
 
 def test_track_actions_truncates_a_long_prompt(state, fzf):
     seen = fzf('Play Track')
 
-    screens.track_actions(state, track_ref('A' * 40))
+    screens.track_actions(state, track_ref('A' * 40), 'search')
 
     assert seen['prompts'][0] == '[{}...] > '.format('A' * 20)
 
@@ -652,7 +685,7 @@ def test_play_track_starts_the_track_on_the_active_device(state, client):
 
     track = track_ref('Song')
 
-    assert screens.play_track(state, track) == ('search',)
+    assert screens.play_track(state, track, 'search') == ('search',)
     assert fake.named('start_playback') == [
         ('start_playback', {'device_id': 'd1', 'uris': ['spotify:track:track-1']})
     ]
@@ -663,14 +696,14 @@ def test_play_track_redirects_when_there_is_no_device(state, client):
 
     track = track_ref('Song')
 
-    assert screens.play_track(state, track) == ('list_devices',)
+    assert screens.play_track(state, track, 'search') == ('list_devices',)
     assert fake.named('start_playback') == []
 
 
 def test_play_track_in_context_uses_the_playlist_as_context(state, client):
     fake = client(playback=track_playback())
 
-    result = screens.play_track_in_context(state, track_ref('Song'))
+    result = screens.play_track_in_context(state, track_ref('Song'), 'search')
 
     assert result == ('search',)
     assert fake.named('start_playback') == [
@@ -696,6 +729,7 @@ def test_play_track_in_context_is_unaffected_by_the_separator_in_a_name(state, c
     screens.play_track_in_context(
         state,
         track_ref('Intro :: Reprise :: Album :: A :: Road Trip'),
+        'search',
     )
 
     kwargs = fake.named('start_playback')[0][1]
@@ -706,7 +740,7 @@ def test_play_track_in_context_is_unaffected_by_the_separator_in_a_name(state, c
 def test_play_track_in_context_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
 
-    result = screens.play_track_in_context(state, track_ref('Song'))
+    result = screens.play_track_in_context(state, track_ref('Song'), 'search')
 
     assert result == ('list_devices',)
     assert fake.named('start_playback') == []
@@ -720,10 +754,10 @@ def test_the_device_redirect_round_trips_back_to_the_original_screen(state, clie
     props = track_ref('Song :: Album :: A :: Road Trip')
     client(playback=None)
 
-    assert screens.play_track(state, props) == ('list_devices',)
+    assert screens.play_track(state, props, 'search') == ('list_devices',)
 
     fake = client()
-    assert screens.device_actions(state, 'd1') == ('play_track', props)
+    assert screens.device_actions(state, 'd1') == ('play_track', props, 'search')
     assert fake.named('transfer_playback') == [('transfer_playback', 'd1')]
     # The redirect state is consumed, so a later visit goes home instead.
     assert state.pending_screen is None
@@ -753,12 +787,12 @@ def test_a_persisted_device_that_no_longer_exists_is_forgotten(state, client):
     client(playback=None, start_error=device_gone())
     state.set_active_device('d1')
 
-    assert screens.play_track(state, props) == ('list_devices',)
+    assert screens.play_track(state, props, 'search') == ('list_devices',)
     assert state.active_device_id is None
     # Forgotten on disk too, or the next session retries the dead device.
     assert AppState.from_config(state.config).active_device_id is None
     # And the redirect still knows what the user was trying to do.
-    assert state.pending_screen == ('play_track', (props,))
+    assert state.pending_screen == ('play_track', (props, 'search'))
 
 
 def test_resume_forgets_a_persisted_device_that_no_longer_exists(state, client):
@@ -777,13 +811,17 @@ def test_track_actions_offers_queueing(state, fzf):
     fzf('Add to Queue')
     track = track_ref('Song :: Album :: A :: Road Trip')
 
-    assert screens.track_actions(state, track) == ('add_to_queue', track)
+    assert screens.track_actions(state, track, 'search') == (
+        'add_to_queue',
+        track,
+        'search',
+    )
 
 
 def test_add_to_queue_queues_on_the_device_that_is_playing(state, client):
     fake = client(playback=track_playback())
 
-    assert screens.add_to_queue(state, track_ref('Song')) == ('search',)
+    assert screens.add_to_queue(state, track_ref('Song'), 'search') == ('search',)
     assert fake.named('add_to_queue') == [
         ('add_to_queue', {'uri': 'spotify:track:track-1', 'device_id': 'device-1'})
     ]
@@ -794,8 +832,10 @@ def test_add_to_queue_returns_to_the_search_so_tracks_can_be_stacked(state, clie
     fake = client(playback=None)
     state.active_device_id = 'd1'
 
-    assert screens.add_to_queue(state, track_ref('Song')) == ('search',)
-    assert screens.add_to_queue(state, track_ref('Other', 'track-2')) == ('search',)
+    assert screens.add_to_queue(state, track_ref('Song'), 'search') == ('search',)
+    assert screens.add_to_queue(state, track_ref('Other', 'track-2'), 'search') == (
+        'search',
+    )
     assert [call[1]['uri'] for call in fake.named('add_to_queue')] == [
         'spotify:track:track-1',
         'spotify:track:track-2',
@@ -806,9 +846,9 @@ def test_add_to_queue_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
     track = track_ref('Song')
 
-    assert screens.add_to_queue(state, track) == ('list_devices',)
+    assert screens.add_to_queue(state, track, 'search') == ('list_devices',)
     assert fake.named('add_to_queue') == []
-    assert state.pending_screen == ('add_to_queue', (track,))
+    assert state.pending_screen == ('add_to_queue', (track, 'search'))
 
 
 def test_add_to_queue_forgets_a_persisted_device_that_no_longer_exists(state, client):
@@ -819,7 +859,7 @@ def test_add_to_queue_forgets_a_persisted_device_that_no_longer_exists(state, cl
     client(playback=None, queue_error=device_gone())
     state.set_active_device('d1')
 
-    assert screens.add_to_queue(state, track_ref('Song')) == ('list_devices',)
+    assert screens.add_to_queue(state, track_ref('Song'), 'search') == ('list_devices',)
     assert state.active_device_id is None
     assert AppState.from_config(state.config).active_device_id is None
 

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -345,22 +345,22 @@ def test_describe_queue_renders_an_episode():
     assert screens.describe_queue(queue) == ['1  Episode One :: The Show :: A Publisher']
 
 
-def test_describe_queue_recognises_an_episode_by_its_show_alone():
+def test_describe_item_recognises_an_episode_by_its_show_alone():
     """Not every episode payload carries type == 'episode'."""
     item = {'name': 'Episode One', 'show': {'name': 'The Show'}}
 
-    assert screens.describe_queue_item(item) == 'Episode One :: The Show'
+    assert screens.describe_item(item) == 'Episode One :: The Show'
 
 
-def test_describe_queue_omits_a_missing_album_and_artists():
+def test_describe_item_omits_a_missing_album_and_artists():
     item = {'type': 'track', 'name': 'Song', 'album': None, 'artists': []}
 
-    assert screens.describe_queue_item(item) == 'Song'
+    assert screens.describe_item(item) == 'Song'
 
 
-def test_describe_queue_names_an_item_it_cannot_describe():
+def test_describe_item_names_an_item_it_cannot_describe():
     """The row still holds a numbered slot, so it may not trail off blank."""
-    assert screens.describe_queue_item({'type': 'track'}) == 'unknown item'
+    assert screens.describe_item({'type': 'track'}) == 'unknown item'
 
 
 def test_describe_queue_keeps_one_item_on_one_row():

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -784,6 +784,31 @@ def test_play_history_tells_two_plays_of_one_track_apart(state, client, fzf, fro
     assert entry.played_at == '2026-08-30T10:00:00Z'
 
 
+def test_play_history_recognises_a_row_that_was_padded_to_line_up(
+    state, client, fzf, frozen_now
+):
+    """
+    Spotify returns up to 50 plays, so the single-digit rows are padded to line
+    up under the two-digit ones. The padding is part of the row, and the row is
+    the key the entry is looked up by.
+    """
+    client(
+        history={
+            'items': [
+                history_item('Song {}'.format(n), track_id='track-{}'.format(n))
+                for n in range(1, 12)
+            ]
+        }
+    )
+    seen = fzf(' 1  Song 1 :: Album :: A, B  (2h ago)')
+
+    choice, entry = screens.play_history(state)
+
+    assert seen['items'][0][0].startswith(' 1  ')
+    assert choice == 'history_actions'
+    assert entry.track_id == 'track-1'
+
+
 def test_home_screen_reaches_the_play_history(state, fzf):
     fzf('[ 7 ] Play History')
 

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -6,7 +6,9 @@ from datetime import datetime, timezone
 import pytest
 from spotipy import SpotifyException
 
+from builders import history_item, playlist_context
 from spotifz.interface import screens
+from spotifz.spotify import history
 from spotifz.spotify.sink import SEPARATOR, TrackRef
 from spotifz.state import AppState
 
@@ -418,178 +420,10 @@ def test_describe_queue_does_not_skip_a_number_for_an_unrenderable_entry():
     assert rows[1].endswith('Song C :: Album :: A, B')
 
 
-# --- the play history renderers ----------------------------------------------
+# --- the play history rows ---------------------------------------------------
 
 
 NOW = datetime(2026, 8, 30, 12, 0, 0, tzinfo=timezone.utc)
-
-
-def history_item(
-    name='Song',
-    track_id='track-1',
-    album='Album',
-    artists=('A', 'B'),
-    context=None,
-    played_at='2026-08-30T10:00:00.123Z',
-):
-    """One entry as `me/player/recently-played` returns it."""
-    return {
-        'track': {
-            'type': 'track',
-            'id': track_id,
-            'name': name,
-            'album': {'name': album},
-            'artists': [{'name': artist} for artist in artists],
-        },
-        'context': context,
-        'played_at': played_at,
-    }
-
-
-def playlist_context(playlist_id='pl-1'):
-    return {'type': 'playlist', 'uri': 'spotify:playlist:{}'.format(playlist_id)}
-
-
-def test_context_playlist_id_reads_a_playlist():
-    assert screens.context_playlist_id(playlist_context('pl-1')) == 'pl-1'
-
-
-@pytest.mark.parametrize(
-    'context',
-    [
-        None,
-        {},
-        {'type': 'album', 'uri': 'spotify:album:al-1'},
-        {'type': 'artist', 'uri': 'spotify:artist:ar-1'},
-        {'type': 'collection', 'uri': 'spotify:user:tester:collection'},
-        {'type': 'playlist', 'uri': 'spotify:playlist:'},
-        {'type': 'playlist'},
-    ],
-)
-def test_context_playlist_id_reads_nothing_else(context):
-    assert screens.context_playlist_id(context) is None
-
-
-def test_history_entries_says_nothing_without_a_response():
-    """No history at all comes back as a 204, which spotipy returns as None."""
-    assert screens.history_entries(None) == []
-    assert screens.history_entries({}) == []
-    assert screens.history_entries({'items': None}) == []
-
-
-def test_history_entries_reads_a_track():
-    entry = screens.history_entries({'items': [history_item()]})[0]
-
-    assert entry.display == 'Song :: Album :: A, B'
-    assert entry.track_id == 'track-1'
-    assert entry.played_at == '2026-08-30T10:00:00.123Z'
-    assert entry.context_uri is None
-    assert entry.context_name is None
-
-
-def test_history_entries_names_a_cached_playlist_on_the_row():
-    response = {'items': [history_item(context=playlist_context('pl-1'))]}
-
-    entry = screens.history_entries(response, {'pl-1': 'Road Trip'})[0]
-
-    assert entry.display == 'Song :: Album :: A, B :: Road Trip'
-    assert entry.context_name == 'Road Trip'
-    assert entry.context_uri == 'spotify:playlist:pl-1'
-    assert entry.context_type == 'playlist'
-
-
-def test_history_entries_leaves_an_uncached_playlist_unnamed():
-    """
-    Someone else's playlist, or one added since the last Update Cache. The row
-    keeps everything the API gave it and just gains no fourth field.
-    """
-    response = {'items': [history_item(context=playlist_context('pl-9'))]}
-
-    entry = screens.history_entries(response, {'pl-1': 'Road Trip'})[0]
-
-    assert entry.display == 'Song :: Album :: A, B'
-    assert entry.context_name is None
-    # Still resumable: the action does not need the name, only the uri.
-    assert entry.context_uri == 'spotify:playlist:pl-9'
-    assert entry.is_resumable
-
-
-def test_history_entries_keeps_an_album_context_off_the_row():
-    """
-    The album is already the row's second field, so repeating it would be
-    noise -- but the entry still knows the name, for the action that offers to
-    resume it.
-    """
-    context = {'type': 'album', 'uri': 'spotify:album:al-1'}
-    response = {'items': [history_item(album='Mezzanine', context=context)]}
-
-    entry = screens.history_entries(response)[0]
-
-    assert entry.display == 'Song :: Mezzanine :: A, B'
-    assert entry.context_name == 'Mezzanine'
-    assert entry.is_resumable
-
-
-def test_history_entries_keeps_a_playlist_name_on_one_row():
-    response = {'items': [history_item(context=playlist_context('pl-1'))]}
-
-    entry = screens.history_entries(response, {'pl-1': 'Road\nTrip'})[0]
-
-    assert entry.display == 'Song :: Album :: A, B :: Road Trip'
-
-
-def test_history_entries_skips_an_entry_without_a_track():
-    response = {'items': [history_item(), None, {'track': None}, history_item('Other')]}
-
-    assert [entry.name for entry in screens.history_entries(response)] == [
-        'Song',
-        'Other',
-    ]
-
-
-def test_an_entry_is_only_resumable_in_a_playlist_or_an_album():
-    """
-    Spotify accepts the offset that starts a context at the chosen track only
-    for those two; anywhere else it would start somewhere the user did not pick.
-    """
-    resumable = {
-        'playlist': 'spotify:playlist:pl-1',
-        'album': 'spotify:album:al-1',
-    }
-    for context_type, uri in resumable.items():
-        context = {'type': context_type, 'uri': uri}
-        assert screens.history_entries({'items': [history_item(context=context)]})[
-            0
-        ].is_resumable, context_type
-
-    not_resumable = {
-        'artist': 'spotify:artist:ar-1',
-        'collection': 'spotify:user:tester:collection',
-    }
-    for context_type, uri in not_resumable.items():
-        context = {'type': context_type, 'uri': uri}
-        assert not screens.history_entries({'items': [history_item(context=context)]})[
-            0
-        ].is_resumable, context_type
-
-    assert not screens.history_entries({'items': [history_item()]})[0].is_resumable
-
-
-def test_history_playlist_ids_lists_what_the_caller_has_to_look_up():
-    response = {
-        'items': [
-            history_item(context=playlist_context('pl-1')),
-            history_item(context={'type': 'album', 'uri': 'spotify:album:al-1'}),
-            history_item(context=None),
-            history_item(context=playlist_context('pl-2')),
-        ]
-    }
-
-    assert screens.history_playlist_ids(response) == ['pl-1', 'pl-2']
-
-
-def test_history_playlist_ids_says_nothing_without_a_response():
-    assert screens.history_playlist_ids(None) == []
 
 
 @pytest.mark.parametrize(
@@ -624,6 +458,41 @@ def test_played_ago_does_not_read_the_future():
 # --- describe_history --------------------------------------------------------
 
 
+def test_describe_history_item_reads_like_a_search_result():
+    entry = history.history_entries({'items': [history_item()]})[0]
+
+    assert screens.describe_history_item(entry) == 'Song :: Album :: A, B'
+
+
+def test_describe_history_item_names_a_playlist_it_knows():
+    entry = history.history_entries(
+        {'items': [history_item(context=playlist_context('pl-1'))]},
+        {'pl-1': 'Road Trip'},
+    )[0]
+
+    assert screens.describe_history_item(entry) == 'Song :: Album :: A, B :: Road Trip'
+
+
+def test_describe_history_item_leaves_an_album_context_off_the_row():
+    """The album is already the row's second field."""
+    context = {'type': 'album', 'uri': 'spotify:album:al-1'}
+    entry = history.history_entries(
+        {'items': [history_item(album='Mezzanine', context=context)]}
+    )[0]
+
+    assert entry.context_name == 'Mezzanine'
+    assert screens.describe_history_item(entry) == 'Song :: Mezzanine :: A, B'
+
+
+def test_describe_history_item_keeps_a_playlist_name_on_one_row():
+    entry = history.history_entries(
+        {'items': [history_item(context=playlist_context('pl-1'))]},
+        {'pl-1': 'Road\nTrip'},
+    )[0]
+
+    assert screens.describe_history_item(entry) == 'Song :: Album :: A, B :: Road Trip'
+
+
 def test_describe_history_says_nothing_without_entries():
     assert screens.describe_history([], NOW) == []
 
@@ -636,7 +505,7 @@ def test_describe_history_numbers_the_rows_newest_first():
         ]
     }
 
-    assert screens.describe_history(screens.history_entries(response), NOW) == [
+    assert screens.describe_history(history.history_entries(response), NOW) == [
         '1  Song A :: Album :: A, B  (2h ago)',
         '2  Song B :: Album :: A, B  (yesterday)',
     ]
@@ -645,7 +514,7 @@ def test_describe_history_numbers_the_rows_newest_first():
 def test_describe_history_lines_up_two_digit_positions():
     response = {'items': [history_item() for _ in range(10)]}
 
-    rows = screens.describe_history(screens.history_entries(response), NOW)
+    rows = screens.describe_history(history.history_entries(response), NOW)
 
     assert rows[0].startswith(' 1  Song')
     assert rows[9].startswith('10  Song')
@@ -658,7 +527,7 @@ def test_describe_history_keeps_two_plays_of_one_track_apart():
     """
     response = {'items': [history_item(), history_item()]}
 
-    rows = screens.describe_history(screens.history_entries(response), NOW)
+    rows = screens.describe_history(history.history_entries(response), NOW)
 
     assert len(set(rows)) == 2
 
@@ -666,7 +535,7 @@ def test_describe_history_keeps_two_plays_of_one_track_apart():
 def test_describe_history_drops_only_the_suffix_for_a_bad_timestamp():
     response = {'items': [history_item(played_at='whenever')]}
 
-    assert screens.describe_history(screens.history_entries(response), NOW) == [
+    assert screens.describe_history(history.history_entries(response), NOW) == [
         '1  Song :: Album :: A, B'
     ]
 
@@ -819,7 +688,7 @@ def test_home_screen_reaches_the_play_history(state, fzf):
 
 
 def history_entry(**kwargs):
-    return screens.history_entries({'items': [history_item(**kwargs)]})[0]
+    return history.history_entries({'items': [history_item(**kwargs)]})[0]
 
 
 def test_history_actions_offers_only_the_track_actions_without_a_context(state, fzf):
@@ -831,7 +700,7 @@ def test_history_actions_offers_only_the_track_actions_without_a_context(state, 
 
 
 def test_history_actions_offers_a_cached_playlist_by_name(state, fzf):
-    entry = screens.history_entries(
+    entry = history.history_entries(
         {'items': [history_item(context=playlist_context('pl-1'))]},
         {'pl-1': 'Road Trip'},
     )[0]
@@ -894,7 +763,7 @@ def test_history_actions_sends_an_action_back_to_the_history(state, fzf):
 
 
 def test_history_actions_routes_the_context_action(state, fzf):
-    entry = screens.history_entries(
+    entry = history.history_entries(
         {'items': [history_item(context=playlist_context('pl-1'))]},
         {'pl-1': 'Road Trip'},
     )[0]

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,4 +1,5 @@
 import inspect
+from datetime import datetime, timezone
 
 import pytest
 from spotipy import SpotifyException
@@ -386,6 +387,254 @@ def test_describe_queue_does_not_skip_a_number_for_an_unrenderable_entry():
 
     assert [row.split('  ')[0] for row in rows] == ['1', '2']
     assert rows[1].endswith('Song C :: Album :: A, B')
+
+
+# --- the play history renderers ----------------------------------------------
+
+
+NOW = datetime(2026, 8, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def history_item(
+    name='Song',
+    track_id='track-1',
+    album='Album',
+    artists=('A', 'B'),
+    context=None,
+    played_at='2026-08-30T10:00:00.123Z',
+):
+    """One entry as `me/player/recently-played` returns it."""
+    return {
+        'track': {
+            'type': 'track',
+            'id': track_id,
+            'name': name,
+            'album': {'name': album},
+            'artists': [{'name': artist} for artist in artists],
+        },
+        'context': context,
+        'played_at': played_at,
+    }
+
+
+def playlist_context(playlist_id='pl-1'):
+    return {'type': 'playlist', 'uri': 'spotify:playlist:{}'.format(playlist_id)}
+
+
+def test_context_playlist_id_reads_a_playlist():
+    assert screens.context_playlist_id(playlist_context('pl-1')) == 'pl-1'
+
+
+@pytest.mark.parametrize(
+    'context',
+    [
+        None,
+        {},
+        {'type': 'album', 'uri': 'spotify:album:al-1'},
+        {'type': 'artist', 'uri': 'spotify:artist:ar-1'},
+        {'type': 'collection', 'uri': 'spotify:user:tester:collection'},
+        {'type': 'playlist', 'uri': 'spotify:playlist:'},
+        {'type': 'playlist'},
+    ],
+)
+def test_context_playlist_id_reads_nothing_else(context):
+    assert screens.context_playlist_id(context) is None
+
+
+def test_history_entries_says_nothing_without_a_response():
+    """No history at all comes back as a 204, which spotipy returns as None."""
+    assert screens.history_entries(None) == []
+    assert screens.history_entries({}) == []
+    assert screens.history_entries({'items': None}) == []
+
+
+def test_history_entries_reads_a_track():
+    entry = screens.history_entries({'items': [history_item()]})[0]
+
+    assert entry.display == 'Song :: Album :: A, B'
+    assert entry.track_id == 'track-1'
+    assert entry.played_at == '2026-08-30T10:00:00.123Z'
+    assert entry.context_uri is None
+    assert entry.context_name is None
+
+
+def test_history_entries_names_a_cached_playlist_on_the_row():
+    response = {'items': [history_item(context=playlist_context('pl-1'))]}
+
+    entry = screens.history_entries(response, {'pl-1': 'Road Trip'})[0]
+
+    assert entry.display == 'Song :: Album :: A, B :: Road Trip'
+    assert entry.context_name == 'Road Trip'
+    assert entry.context_uri == 'spotify:playlist:pl-1'
+    assert entry.context_type == 'playlist'
+
+
+def test_history_entries_leaves_an_uncached_playlist_unnamed():
+    """
+    Someone else's playlist, or one added since the last Update Cache. The row
+    keeps everything the API gave it and just gains no fourth field.
+    """
+    response = {'items': [history_item(context=playlist_context('pl-9'))]}
+
+    entry = screens.history_entries(response, {'pl-1': 'Road Trip'})[0]
+
+    assert entry.display == 'Song :: Album :: A, B'
+    assert entry.context_name is None
+    # Still resumable: the action does not need the name, only the uri.
+    assert entry.context_uri == 'spotify:playlist:pl-9'
+    assert entry.is_resumable
+
+
+def test_history_entries_does_not_name_an_album_context():
+    """The album is already the row's second field."""
+    context = {'type': 'album', 'uri': 'spotify:album:al-1'}
+    response = {'items': [history_item(context=context)]}
+
+    entry = screens.history_entries(response)[0]
+
+    assert entry.display == 'Song :: Album :: A, B'
+    assert entry.is_resumable
+
+
+def test_history_entries_keeps_a_playlist_name_on_one_row():
+    response = {'items': [history_item(context=playlist_context('pl-1'))]}
+
+    entry = screens.history_entries(response, {'pl-1': 'Road\nTrip'})[0]
+
+    assert entry.display == 'Song :: Album :: A, B :: Road Trip'
+
+
+def test_history_entries_skips_an_entry_without_a_track():
+    response = {'items': [history_item(), None, {'track': None}, history_item('Other')]}
+
+    assert [entry.name for entry in screens.history_entries(response)] == [
+        'Song',
+        'Other',
+    ]
+
+
+def test_an_entry_is_only_resumable_in_a_playlist_or_an_album():
+    """
+    Spotify accepts the offset that starts a context at the chosen track only
+    for those two; anywhere else it would start somewhere the user did not pick.
+    """
+    resumable = {
+        'playlist': 'spotify:playlist:pl-1',
+        'album': 'spotify:album:al-1',
+    }
+    for context_type, uri in resumable.items():
+        context = {'type': context_type, 'uri': uri}
+        assert screens.history_entries({'items': [history_item(context=context)]})[
+            0
+        ].is_resumable, context_type
+
+    not_resumable = {
+        'artist': 'spotify:artist:ar-1',
+        'collection': 'spotify:user:tester:collection',
+    }
+    for context_type, uri in not_resumable.items():
+        context = {'type': context_type, 'uri': uri}
+        assert not screens.history_entries({'items': [history_item(context=context)]})[
+            0
+        ].is_resumable, context_type
+
+    assert not screens.history_entries({'items': [history_item()]})[0].is_resumable
+
+
+def test_history_playlist_ids_lists_what_the_caller_has_to_look_up():
+    response = {
+        'items': [
+            history_item(context=playlist_context('pl-1')),
+            history_item(context={'type': 'album', 'uri': 'spotify:album:al-1'}),
+            history_item(context=None),
+            history_item(context=playlist_context('pl-2')),
+        ]
+    }
+
+    assert screens.history_playlist_ids(response) == ['pl-1', 'pl-2']
+
+
+def test_history_playlist_ids_says_nothing_without_a_response():
+    assert screens.history_playlist_ids(None) == []
+
+
+@pytest.mark.parametrize(
+    'played_at,expected',
+    [
+        ('2026-08-30T11:59:40Z', 'just now'),
+        ('2026-08-30T11:55:00Z', '5m ago'),
+        ('2026-08-30T10:00:00Z', '2h ago'),
+        ('2026-08-29T12:00:00Z', 'yesterday'),
+        ('2026-08-27T12:00:00Z', '3d ago'),
+        # The fractional seconds Spotify actually sends, and a Z-less form.
+        ('2026-08-30T10:00:00.123Z', '2h ago'),
+        ('2026-08-30T10:00:00.123456Z', '2h ago'),
+        ('2026-08-30T10:00:00', '2h ago'),
+    ],
+)
+def test_played_ago_reads_compactly(played_at, expected):
+    assert screens.played_ago(played_at, NOW) == expected
+
+
+@pytest.mark.parametrize('played_at', ['', None, 'yesterday', '2026-08-30'])
+def test_played_ago_says_nothing_it_cannot_work_out(played_at):
+    """A row loses its suffix rather than the screen losing the row."""
+    assert screens.played_ago(played_at, NOW) == ''
+
+
+def test_played_ago_does_not_read_the_future():
+    """The clock here and Spotify's need not agree to the second."""
+    assert screens.played_ago('2026-08-30T12:00:30Z', NOW) == 'just now'
+
+
+# --- describe_history --------------------------------------------------------
+
+
+def test_describe_history_says_nothing_without_entries():
+    assert screens.describe_history([], NOW) == []
+
+
+def test_describe_history_numbers_the_rows_newest_first():
+    response = {
+        'items': [
+            history_item('Song A', played_at='2026-08-30T10:00:00Z'),
+            history_item('Song B', played_at='2026-08-29T12:00:00Z'),
+        ]
+    }
+
+    assert screens.describe_history(screens.history_entries(response), NOW) == [
+        '1  Song A :: Album :: A, B  (2h ago)',
+        '2  Song B :: Album :: A, B  (yesterday)',
+    ]
+
+
+def test_describe_history_lines_up_two_digit_positions():
+    response = {'items': [history_item() for _ in range(10)]}
+
+    rows = screens.describe_history(screens.history_entries(response), NOW)
+
+    assert rows[0].startswith(' 1  Song')
+    assert rows[9].startswith('10  Song')
+
+
+def test_describe_history_keeps_two_plays_of_one_track_apart():
+    """
+    The row is the key the screen maps back to an entry, so a repeat has to
+    render as its own row rather than collapsing onto the first.
+    """
+    response = {'items': [history_item(), history_item()]}
+
+    rows = screens.describe_history(screens.history_entries(response), NOW)
+
+    assert len(set(rows)) == 2
+
+
+def test_describe_history_drops_only_the_suffix_for_a_bad_timestamp():
+    response = {'items': [history_item(played_at='whenever')]}
+
+    assert screens.describe_history(screens.history_entries(response), NOW) == [
+        '1  Song :: Album :: A, B'
+    ]
 
 
 # --- current_playback --------------------------------------------------------

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -126,7 +126,7 @@ EXPECTED_SCREENS = {
     'update_cache',
     'track_actions',
     'play_track',
-    'play_track_in_playlist',
+    'play_track_in_context',
     'add_to_queue',
 }
 
@@ -667,10 +667,10 @@ def test_play_track_redirects_when_there_is_no_device(state, client):
     assert fake.named('start_playback') == []
 
 
-def test_play_track_in_playlist_uses_the_playlist_as_context(state, client):
+def test_play_track_in_context_uses_the_playlist_as_context(state, client):
     fake = client(playback=track_playback())
 
-    result = screens.play_track_in_playlist(state, track_ref('Song'))
+    result = screens.play_track_in_context(state, track_ref('Song'))
 
     assert result == ('search',)
     assert fake.named('start_playback') == [
@@ -685,7 +685,7 @@ def test_play_track_in_playlist_uses_the_playlist_as_context(state, client):
     ]
 
 
-def test_play_track_in_playlist_is_unaffected_by_the_separator_in_a_name(state, client):
+def test_play_track_in_context_is_unaffected_by_the_separator_in_a_name(state, client):
     """
     A name containing ' :: ' used to add fields, which is why the ids were
     addressed by negative index. They have names now, and the name is just
@@ -693,7 +693,7 @@ def test_play_track_in_playlist_is_unaffected_by_the_separator_in_a_name(state, 
     """
     fake = client(playback=track_playback())
 
-    screens.play_track_in_playlist(
+    screens.play_track_in_context(
         state,
         track_ref('Intro :: Reprise :: Album :: A :: Road Trip'),
     )
@@ -703,10 +703,10 @@ def test_play_track_in_playlist_is_unaffected_by_the_separator_in_a_name(state, 
     assert kwargs['offset'] == {'uri': 'spotify:track:track-1'}
 
 
-def test_play_track_in_playlist_redirects_when_there_is_no_device(state, client):
+def test_play_track_in_context_redirects_when_there_is_no_device(state, client):
     fake = client(playback=None)
 
-    result = screens.play_track_in_playlist(state, track_ref('Song'))
+    result = screens.play_track_in_context(state, track_ref('Song'))
 
     assert result == ('list_devices',)
     assert fake.named('start_playback') == []

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -1,4 +1,6 @@
 import inspect
+import json
+import os
 from datetime import datetime, timezone
 
 import pytest
@@ -20,13 +22,20 @@ def track_ref(display, track_id='track-1', playlist_id='pl-1'):
 
 class FakeClient:
     def __init__(
-        self, playback=None, devices=(), start_error=None, queue=None, queue_error=None
+        self,
+        playback=None,
+        devices=(),
+        start_error=None,
+        queue=None,
+        queue_error=None,
+        history=None,
     ):
         self._playback = playback
         self._devices = list(devices)
         self._start_error = start_error
         self._queue = queue
         self._queue_error = queue_error
+        self._history = history
         self.calls = []
 
     def current_playback(self, **kwargs):
@@ -40,6 +49,10 @@ class FakeClient:
     def queue(self):
         self.calls.append(('queue', {}))
         return self._queue
+
+    def current_user_recently_played(self, **kwargs):
+        self.calls.append(('current_user_recently_played', kwargs))
+        return self._history
 
     def transfer_playback(self, device_id):
         self.calls.append(('transfer_playback', device_id))
@@ -69,9 +82,14 @@ def client(monkeypatch):
     """
 
     def _install(
-        playback=None, devices=(), start_error=None, queue=None, queue_error=None
+        playback=None,
+        devices=(),
+        start_error=None,
+        queue=None,
+        queue_error=None,
+        history=None,
     ):
-        fake = FakeClient(playback, devices, start_error, queue, queue_error)
+        fake = FakeClient(playback, devices, start_error, queue, queue_error, history)
         monkeypatch.setattr(screens.spotify, 'get_spotify_client', lambda cfg: fake)
         return fake
 
@@ -121,6 +139,8 @@ EXPECTED_SCREENS = {
     'search',
     'current_playback',
     'current_queue',
+    'play_history',
+    'history_actions',
     'list_devices',
     'device_actions',
     'resume',
@@ -153,7 +173,14 @@ def test_the_registry_keys_are_the_function_names():
         assert fn.__name__ == name
 
 
-@pytest.mark.parametrize('menu', [screens.HOME_CHOICES, screens.TRACK_ACTIONS_CHOICES])
+@pytest.mark.parametrize(
+    'menu',
+    [
+        screens.HOME_CHOICES,
+        screens.TRACK_ACTIONS_CHOICES,
+        screens.HISTORY_ACTIONS_CHOICES,
+    ],
+)
 def test_every_menu_destination_is_a_registered_screen(menu):
     for label, destination in menu.items():
         assert destination in screens.SCREENS, label
@@ -164,9 +191,11 @@ def test_every_track_action_accepts_the_screen_it_was_entered_from():
     An action that dropped `origin` would compile and then strand the user on
     whichever screen its own return value happened to name.
     """
-    for label, destination in screens.TRACK_ACTIONS_CHOICES.items():
-        params = list(inspect.signature(screens.SCREENS[destination]).parameters)
-        assert params[-1] == 'origin', label
+    menus = (screens.TRACK_ACTIONS_CHOICES, screens.HISTORY_ACTIONS_CHOICES)
+    for menu in menus:
+        for label, destination in menu.items():
+            params = list(inspect.signature(screens.SCREENS[destination]).parameters)
+            assert params[-1] == 'origin', label
 
 
 def test_a_helper_that_takes_the_state_is_not_a_screen():
@@ -635,6 +664,255 @@ def test_describe_history_drops_only_the_suffix_for_a_bad_timestamp():
     assert screens.describe_history(screens.history_entries(response), NOW) == [
         '1  Song :: Album :: A, B'
     ]
+
+
+# --- play_history ------------------------------------------------------------
+
+
+@pytest.fixture
+def frozen_now(monkeypatch):
+    """Holds the clock the rows' relative times are read against."""
+    monkeypatch.setattr(screens, 'current_time', lambda: NOW)
+    return NOW
+
+
+def test_play_history_returns_home_without_prompting(state, client, fzf):
+    client(history=None)
+    seen = fzf()
+
+    assert screens.play_history(state) == ('home_screen',)
+    assert seen['items'] == []
+
+
+def test_play_history_shows_the_rows(state, client, fzf, frozen_now):
+    client(
+        history={
+            'items': [
+                history_item('Song A', played_at='2026-08-30T11:59:40Z'),
+                history_item('Song B', played_at='2026-08-30T11:55:00Z'),
+            ]
+        }
+    )
+    seen = fzf('')
+
+    assert screens.play_history(state) == ('home_screen',)
+    assert seen['items'][0] == [
+        '1  Song A :: Album :: A, B  (just now)',
+        '2  Song B :: Album :: A, B  (5m ago)',
+    ]
+    assert seen['prompts'] == ['[History] > ']
+
+
+def test_play_history_names_a_playlist_it_has_cached(
+    state, client, fzf, playlist_dir, frozen_now
+):
+    """
+    The whole point of reading the cache: a track played from one of your own
+    playlists says which one.
+    """
+    with open(os.path.join(playlist_dir, 'pl-1'), 'w') as ofile:
+        json.dump({'id': 'pl-1', 'name': 'Road Trip'}, ofile)
+    client(history={'items': [history_item(context=playlist_context('pl-1'))]})
+    seen = fzf('')
+
+    screens.play_history(state)
+
+    assert seen['items'][0] == ['1  Song :: Album :: A, B :: Road Trip  (2h ago)']
+
+
+def test_play_history_leaves_a_playlist_it_has_not_cached_unnamed(
+    state, client, fzf, playlist_dir, frozen_now
+):
+    client(history={'items': [history_item(context=playlist_context('pl-9'))]})
+    seen = fzf('')
+
+    screens.play_history(state)
+
+    assert seen['items'][0] == ['1  Song :: Album :: A, B  (2h ago)']
+
+
+def test_play_history_hands_the_chosen_row_to_the_actions(state, client, fzf, frozen_now):
+    client(history={'items': [history_item('Song A'), history_item('Song B')]})
+    fzf('2  Song B :: Album :: A, B  (2h ago)')
+
+    choice, entry = screens.play_history(state)
+
+    assert choice == 'history_actions'
+    assert entry.name == 'Song B'
+
+
+def test_play_history_returns_home_when_nothing_was_selected(state, client, fzf):
+    client(history={'items': [history_item()]})
+    fzf('')
+
+    assert screens.play_history(state) == ('home_screen',)
+
+
+def test_play_history_returns_home_for_a_row_it_does_not_recognise(state, client, fzf):
+    """
+    fzf can only return a line it was given, so this is a bug guard rather than
+    a path a user can take -- and it must not be a KeyError out of cli.main.
+    """
+    client(history={'items': [history_item()]})
+    fzf('something else entirely')
+
+    assert screens.play_history(state) == ('home_screen',)
+
+
+def test_play_history_tells_two_plays_of_one_track_apart(state, client, fzf, frozen_now):
+    """
+    The rows are the keys the entries are looked up by, so a repeat has to be
+    reachable rather than shadowed by the first play of the same track.
+    """
+    client(
+        history={
+            'items': [
+                history_item(played_at='2026-08-30T11:00:00Z'),
+                history_item(played_at='2026-08-30T10:00:00Z'),
+            ]
+        }
+    )
+    fzf('2  Song :: Album :: A, B  (2h ago)')
+
+    _, entry = screens.play_history(state)
+
+    assert entry.played_at == '2026-08-30T10:00:00Z'
+
+
+def test_home_screen_reaches_the_play_history(state, fzf):
+    fzf('[ 7 ] Play History')
+
+    assert screens.home_screen(state) == ('play_history',)
+
+
+# --- history_actions ---------------------------------------------------------
+
+
+def history_entry(**kwargs):
+    return screens.history_entries({'items': [history_item(**kwargs)]})[0]
+
+
+def test_history_actions_offers_only_the_track_actions_without_a_context(state, fzf):
+    seen = fzf('')
+
+    screens.history_actions(state, history_entry())
+
+    assert seen['items'][0] == ['Play Track', 'Add to Queue']
+
+
+def test_history_actions_offers_a_cached_playlist_by_name(state, fzf):
+    entry = screens.history_entries(
+        {'items': [history_item(context=playlist_context('pl-1'))]},
+        {'pl-1': 'Road Trip'},
+    )[0]
+    seen = fzf('')
+
+    screens.history_actions(state, entry)
+
+    assert seen['items'][0] == ['Play Track', 'Add to Queue', 'Play in Road Trip']
+
+
+def test_history_actions_offers_an_album_by_the_name_on_the_row(state, fzf):
+    """
+    An album context is not named on the row, because the album is already the
+    row's second field -- which is where the label reads it from.
+    """
+    entry = history_entry(
+        album='Mezzanine', context={'type': 'album', 'uri': 'spotify:album:al-1'}
+    )
+    seen = fzf('')
+
+    screens.history_actions(state, entry)
+
+    assert seen['items'][0][2] == 'Play in Mezzanine'
+
+
+def test_history_actions_offers_an_uncached_playlist_without_a_name(state, fzf):
+    """The action needs the uri, not the name, so it is still worth offering."""
+    entry = history_entry(context=playlist_context('pl-9'))
+    seen = fzf('')
+
+    screens.history_actions(state, entry)
+
+    assert seen['items'][0][2] == 'Play in Playlist'
+
+
+@pytest.mark.parametrize(
+    'context',
+    [
+        {'type': 'artist', 'uri': 'spotify:artist:ar-1'},
+        {'type': 'collection', 'uri': 'spotify:user:tester:collection'},
+    ],
+)
+def test_history_actions_does_not_offer_a_context_it_cannot_start(state, fzf, context):
+    seen = fzf('')
+
+    screens.history_actions(state, history_entry(context=context))
+
+    assert seen['items'][0] == ['Play Track', 'Add to Queue']
+
+
+def test_history_actions_sends_an_action_back_to_the_history(state, fzf):
+    entry = history_entry()
+    fzf('Add to Queue')
+
+    assert screens.history_actions(state, entry) == (
+        'add_to_queue',
+        entry,
+        'play_history',
+    )
+
+
+def test_history_actions_routes_the_context_action(state, fzf):
+    entry = screens.history_entries(
+        {'items': [history_item(context=playlist_context('pl-1'))]},
+        {'pl-1': 'Road Trip'},
+    )[0]
+    fzf('Play in Road Trip')
+
+    assert screens.history_actions(state, entry) == (
+        'play_track_in_context',
+        entry,
+        'play_history',
+    )
+
+
+def test_history_actions_returns_to_the_history_on_an_empty_selection(state, fzf):
+    fzf('')
+
+    assert screens.history_actions(state, history_entry()) == ('play_history',)
+
+
+def test_history_actions_truncates_a_long_prompt(state, fzf):
+    seen = fzf('Play Track')
+
+    screens.history_actions(state, history_entry(name='A' * 40))
+
+    assert seen['prompts'][0] == '[{}...] > '.format('A' * 20)
+
+
+def test_a_history_entry_plays_through_the_track_screens_unchanged(state, client):
+    """
+    play_track and add_to_queue read only track_id, which is why an entry can
+    be handed to them without their knowing it is not a TrackRef.
+    """
+    fake = client(playback=track_playback())
+    entry = history_entry(track_id='track-9')
+
+    assert screens.play_track(state, entry, 'play_history') == ('play_history',)
+    assert fake.named('start_playback')[0][1]['uris'] == ['spotify:track:track-9']
+
+
+def test_a_history_entry_resumes_the_context_it_was_played_in(state, client):
+    fake = client(playback=track_playback())
+    entry = history_entry(context=playlist_context('pl-1'))
+
+    assert screens.play_track_in_context(state, entry, 'play_history') == (
+        'play_history',
+    )
+    kwargs = fake.named('start_playback')[0][1]
+    assert kwargs['context_uri'] == 'spotify:playlist:pl-1'
+    assert kwargs['offset'] == {'uri': 'spotify:track:track-1'}
 
 
 # --- current_playback --------------------------------------------------------

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -7,6 +7,7 @@ from spotifz.spotify.sink import (
     PLAYLIST_NAME_FIELD,
     SEPARATOR,
     TRACK_ID_FIELD,
+    TrackRef,
     format_track_line,
     parse_track_line,
     sink_all_tracks,
@@ -246,3 +247,13 @@ def test_parse_track_line_round_trips_what_format_wrote(make_track):
     # ...but `name` is prompt decoration and stops at the display separator.
     # Cosmetic, and the only thing ' :: ' in a name still affects.
     assert ref.name == 'Song'
+
+
+def test_track_ref_names_its_playlist_as_the_playback_context():
+    """
+    A track found through the search was found inside a playlist, so that is
+    what `Play Track in Playlist` starts.
+    """
+    ref = TrackRef('Song :: Album :: A', 'track-1', 'pl-1', 'Road Trip', '')
+
+    assert ref.context_uri == 'spotify:playlist:pl-1'

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,6 +8,7 @@ from spotifz.spotify.storage import (
     extract_fields,
     iter_spotify_reponse,
     prune_backups,
+    read_playlist_names,
     update_cache,
 )
 
@@ -255,6 +256,68 @@ def test_cache_data_skips_a_track_whose_id_is_missing(config, make_track, capsys
     assert 'First' in capsys.readouterr().out
     # The playlist itself is still written, album included.
     assert os.path.exists(os.path.join(config['data_paths']['playlist_path'], 'pl-1'))
+
+
+# --- read_playlist_names -----------------------------------------------------
+
+
+def write_cached_playlist(config, playlist_id, contents):
+    playlist_dir = config['data_paths']['playlist_path']
+    os.makedirs(playlist_dir, exist_ok=True)
+    with open(os.path.join(playlist_dir, playlist_id), 'w') as ofile:
+        ofile.write(contents)
+
+
+def test_read_playlist_names_names_the_cached_playlists(config):
+    write_cached_playlist(config, 'pl-1', json.dumps({'id': 'pl-1', 'name': 'Road Trip'}))
+    write_cached_playlist(
+        config, 'pl-2', json.dumps({'id': 'pl-2', 'name': 'Late Night'})
+    )
+
+    assert read_playlist_names(config, ['pl-1', 'pl-2']) == {
+        'pl-1': 'Road Trip',
+        'pl-2': 'Late Night',
+    }
+
+
+def test_read_playlist_names_opens_only_the_ids_it_was_asked_for(config):
+    write_cached_playlist(config, 'pl-1', json.dumps({'name': 'Road Trip'}))
+    write_cached_playlist(config, 'pl-2', json.dumps({'name': 'Late Night'}))
+
+    assert read_playlist_names(config, ['pl-1']) == {'pl-1': 'Road Trip'}
+
+
+def test_read_playlist_names_omits_a_playlist_that_is_not_cached(config):
+    """
+    Someone else's playlist, or one added since the last update. The row loses
+    its name and keeps everything else.
+    """
+    assert read_playlist_names(config, ['pl-unknown']) == {}
+
+
+def test_read_playlist_names_survives_a_half_written_file(config):
+    """An update killed part way through leaves truncated JSON behind."""
+    write_cached_playlist(config, 'pl-1', '{"id": "pl-1", "na')
+
+    assert read_playlist_names(config, ['pl-1']) == {}
+
+
+def test_read_playlist_names_survives_a_file_that_is_not_an_object(config):
+    write_cached_playlist(config, 'pl-1', json.dumps(['Road Trip']))
+
+    assert read_playlist_names(config, ['pl-1']) == {}
+
+
+def test_read_playlist_names_ignores_an_id_that_is_not_a_path_segment(config):
+    """
+    The id arrives inside a uri from an API response, and is used to name a
+    file. Nothing that could address a file outside the cache is looked up.
+    """
+    assert read_playlist_names(config, ['../../etc/passwd', '', '.']) == {}
+
+
+def test_read_playlist_names_takes_no_offence_at_a_missing_cache(config):
+    assert read_playlist_names(config, ['pl-1']) == {}
 
 
 def test_prune_backups_keeps_only_the_newest(tmp_path):


### PR DESCRIPTION
Adds `[ 7 ] Play History`, backed by `me/player/recently-played`. A row names the playlist a track was played from when that playlist is one of your own; selecting one offers Play Track, Add to Queue, and resuming the playlist or album it was played in.

Needs the `user-read-recently-played` scope, so the first run after this re-authorizes in the browser.

The playlist name comes from the local cache rather than the API, so naming every row costs no request. The trade is that a playlist you have not cached goes unnamed — the action still works, since it needs the uri and not the name.

Resuming a context is offered only for a playlist or an album. Those are the two Spotify accepts `offset` for, and without it an artist or Liked Songs context would start somewhere the user did not pick.

Two refactors came first, both because the history is the second caller of things that had only ever had one. `play_track_in_playlist` composed its context uri from a playlist id; it now takes the uri, since the history arrives holding one already. The track actions all returned to the search because the search was the only way to reach them; they now return to the screen they were entered from.

`played_ago` parses a fixed prefix of the timestamp rather than using `fromisoformat`, which only accepts Spotify's trailing `Z` from 3.11 — CI runs 3.9.

The last commit is a bug this feature exposed rather than introduced: `run_fzf` stripped the whole selection instead of just the newline, so any row padded to line up under a wider one came back a character short. Only the history matches a selection back against a padded row, so nothing else showed it.
