### PR TITLE
Move Update Cache to the end of the home menu

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,13 +7,13 @@ in the terminal
 
 Home Screen:
 
-1. [x] Devices
+1. [x] Search Library
 2. [x] Current Playback
-3. [x] Update Cache
+3. [x] Devices
 4. [x] Play/Pause
-5. [x] Search My Library
-6. [x] Current Queue
-7. [x] Play History
+5. [x] Current Queue
+6. [x] Play History
+7. [x] Update Cache
 
 Selected Track:
 

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -85,9 +85,11 @@ HOME_CHOICES = {
     '[ 2 ] Current Playback': 'current_playback',
     '[ 3 ] Devices': 'list_devices',
     '[ 4 ] Play/Pause': 'resume',
-    '[ 5 ] Update Cache': 'update_cache',
-    '[ 6 ] Current Queue': 'current_queue',
-    '[ 7 ] Play History': 'play_history',
+    '[ 5 ] Current Queue': 'current_queue',
+    '[ 6 ] Play History': 'play_history',
+    # Last: the one entry that is maintenance rather than playback, and the
+    # only one that goes away and rebuilds the library before it returns.
+    '[ 7 ] Update Cache': 'update_cache',
 }
 
 TRACK_ACTIONS_CHOICES = {

--- a/spotifz/interface/screens.py
+++ b/spotifz/interface/screens.py
@@ -87,8 +87,6 @@ HOME_CHOICES = {
     '[ 4 ] Play/Pause': 'resume',
     '[ 5 ] Current Queue': 'current_queue',
     '[ 6 ] Play History': 'play_history',
-    # Last: the one entry that is maintenance rather than playback, and the
-    # only one that goes away and rebuilds the library before it returns.
     '[ 7 ] Update Cache': 'update_cache',
 }
 

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -200,6 +200,15 @@ def test_every_track_action_accepts_the_screen_it_was_entered_from():
             assert params[-1] == 'origin', label
 
 
+def test_the_home_menu_is_numbered_in_the_order_it_is_shown():
+    """
+    fzf lists the labels in the order they are declared, so a number that does
+    not match a label's position is a menu that counts wrong on screen.
+    """
+    for position, label in enumerate(screens.HOME_CHOICES, 1):
+        assert label.startswith('[ {} ] '.format(position)), label
+
+
 def test_a_helper_that_takes_the_state_is_not_a_screen():
     """
     sp_devices has a screen's signature and is called directly by list_devices.
@@ -679,7 +688,7 @@ def test_play_history_recognises_a_row_that_was_padded_to_line_up(
 
 
 def test_home_screen_reaches_the_play_history(state, fzf):
-    fzf('[ 7 ] Play History')
+    fzf('[ 6 ] Play History')
 
     assert screens.home_screen(state) == ('play_history',)
 
@@ -883,7 +892,7 @@ def test_current_queue_returns_home_whatever_is_selected(state, client, fzf):
 
 
 def test_home_screen_reaches_the_queue(state, fzf):
-    fzf('[ 6 ] Current Queue')
+    fzf('[ 5 ] Current Queue')
 
     assert screens.home_screen(state) == ('current_queue',)
 


### PR DESCRIPTION
Update Cache is maintenance rather than playback, and the only entry that deletes the cached library and rebuilds it before returning, so it moves off position 5 and to the end. The rest keep their relative order.

The readme's Home Screen list was in a different order from the menu it claimed to describe, and used a label the menu does not ("Search My Library"). It now matches the menu exactly.

The new test pins each label's number to its position in the menu, which is the part of a hand-numbered reorder that goes wrong quietly.
